### PR TITLE
[FF-0] backdrop(modal) reference for content(modalFrame)

### DIFF
--- a/generics/components/organisms/Modal.mjs
+++ b/generics/components/organisms/Modal.mjs
@@ -1,11 +1,11 @@
 import {slot} from "../../../core/helpers.mjs";
 import {Component} from "../../../core/Component.mjs";
 
-
 export function Modal(content) {
     Component.call(this)
 
     this.content = content
+    this.content.modal = this;
 
     this.getHtml = function() {
         return `
@@ -41,5 +41,4 @@ export function Modal(content) {
     this.show= function() {
         document.body.append(this.getElement())
     }
-
 }


### PR DESCRIPTION
This PR is dependent upon [UC-29] improved code to avoid future bugs

Added the following line to allow the modalFrame to remove the frame and the backdrop
`this.content.modal = this;`

