### PR TITLE
UC-74-created new template views and models for UC-74

### DIFF
--- a/generics/components/templates/Template_ListAllInformation_Model.mjs
+++ b/generics/components/templates/Template_ListAllInformation_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_ListAllInformation_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_ListAllInformation_View.mjs
+++ b/generics/components/templates/Template_ListAllInformation_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_ListAllInformation_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}

--- a/generics/components/templates/Template_ListAllOrganisation_Model.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_ListAllOrganisation_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_ListAllOrganisation_View.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_ListAllOrganisation_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}

--- a/generics/components/templates/Template_ListAllProcesses_Model.mjs
+++ b/generics/components/templates/Template_ListAllProcesses_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_ListAllProcesses_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_ListAllProcesses_View.mjs
+++ b/generics/components/templates/Template_ListAllProcesses_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_ListAllProcesses_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_Projects_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_Projects_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_SearchResult_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_SearchResult_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -1,0 +1,14 @@
+import { SEND_VIEWSTATE_TO_STATE } from "../../../core/actions/action_send_view_state.mjs";
+
+export function Template_Search_Model(model) { 
+    const template_model = {
+            view: model.view,
+            components: {
+               atom_heading4 : {
+                text : model.startHeading
+               }
+            }
+        }
+
+    SEND_VIEWSTATE_TO_STATE(template_model)
+}

--- a/generics/components/templates/Template_Search_View.mjs
+++ b/generics/components/templates/Template_Search_View.mjs
@@ -1,0 +1,22 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { State } from "nd_frontend/core/actions/State.mjs";
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Template_Search_View(view){
+    
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `<div>
+        ${slot("atomHeader")}
+        </div>`
+    }
+
+    this.bindScript = function() {
+        let model = State.views[view].components;
+        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+
+        this.fillSlot("atomHeader", atom_heading4.getElement())
+    }
+}


### PR DESCRIPTION
created the template views and models for https://github.com/nikolai4D/UrbanCloud-alt1/tree/UC-74-Create-empty-and-route-to-project-search-searchresult-listallorganisation-listallinformation-listallprocesses.

### To test: 
* merge UC-74 to dev and this ticket into main
* run app w build
* type in localhost:3001/
* localhost:3001/search
* localhost:3001/searchresult
* localhost:3001/organisation
* localhost:3001/information
* localhost:3001/process
* localhost:3001/projects

All pages have a h4 saying you're in the view.