### PR TITLE
Uc 95 change navbar according to mockup without modal

### DIFF
--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -11,6 +11,6 @@ export function Link(data){
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", this.data.onClick)
+        this.element.addEventListener("click", this.onClick)
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,5 +1,4 @@
 import {Component} from "../../../core/Component.mjs";
-// import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(model){
     Component.call(this)

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -4,13 +4,13 @@ import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 export function Link(data){
     Component.call(this)
 
-    this.onClick = this.onClick
+    this.onClick = onClick
 
     this.getHtml = function(){
         return `<a  class="${data.class}">${data.text}</a>`
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", this.onClick(data.route))
+        this.element.addEventListener("click", this.data.onClick)
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,14 +1,14 @@
 import {Component} from "../../../core/Component.mjs";
-import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
+// import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
-export function Link(data){
+export function Link(model){
     Component.call(this)
 
     this.getHtml = function(){
-        return `<a  class="${data.class}">${data.text}</a>`
+        return `<a  class="${model.class}">${model.text}</a>`
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", ()=> router.goTo(data.route))
+        this.element.addEventListener("click", model.onClick)
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,5 +1,5 @@
 import {Component} from "../../../core/Component.mjs";
-import {router} from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
+// import {router} from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,5 +1,4 @@
 import {Component} from "../../../core/Component.mjs";
-// import {router} from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -4,13 +4,11 @@ import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 export function Link(data){
     Component.call(this)
 
-    this.onClick = onClick
-
     this.getHtml = function(){
         return `<a  class="${data.class}">${data.text}</a>`
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", this.onClick)
+        this.element.addEventListener("click", ()=> router.goTo(data.route))
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,4 +1,5 @@
 import {Component} from "../../../core/Component.mjs";
+import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,5 +1,5 @@
 import {Component} from "../../../core/Component.mjs";
-import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
+// import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)
@@ -9,6 +9,6 @@ export function Link(data){
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", ()=> router.goTo(data.route))
+        this.element.addEventListener("click", this.data.route)
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,14 +1,16 @@
 import {Component} from "../../../core/Component.mjs";
-// import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
+import { router } from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)
+
+    this.onClick = this.onClick
 
     this.getHtml = function(){
         return `<a  class="${data.class}">${data.text}</a>`
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", ()=> router.goTo(data.route))
+        this.element.addEventListener("click", this.onClick(data.route))
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -1,4 +1,5 @@
 import {Component} from "../../../core/Component.mjs";
+import {router} from "../../../../UrbanCloud-alt1/src/javascript/index.mjs";
 
 export function Link(data){
     Component.call(this)
@@ -8,6 +9,6 @@ export function Link(data){
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", ()=> data.router.goTo(data.route))
+        this.element.addEventListener("click", ()=> router.goTo(data.route))
     }
 }

--- a/generics/components/atoms/Link.mjs
+++ b/generics/components/atoms/Link.mjs
@@ -9,6 +9,6 @@ export function Link(data){
     }
 
     this.bindScript = function(){
-        this.element.addEventListener("click", this.data.route)
+        this.element.addEventListener("click", ()=> router.goTo(data.route))
     }
 }

--- a/generics/components/templates/Template_ListAllInformation_Model.mjs
+++ b/generics/components/templates/Template_ListAllInformation_Model.mjs
@@ -21,7 +21,8 @@ export function Template_ListAllInformation_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1.text,
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -29,7 +30,8 @@ export function Template_ListAllInformation_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -37,7 +39,8 @@ export function Template_ListAllInformation_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -45,7 +48,8 @@ export function Template_ListAllInformation_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -53,7 +57,9 @@ export function Template_ListAllInformation_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            onClick: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_ListAllOrganisation_Model.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_Model.mjs
@@ -16,12 +16,13 @@ export function Template_ListAllOrganisation_Model(model) {
                             text : model.logoText
                         }
                     },
-                    molecule_iconAndLink1 : {
+                     molecule_iconAndLink1 : {
                         atom_icon : {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1.text,
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -29,7 +30,8 @@ export function Template_ListAllOrganisation_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -37,7 +39,8 @@ export function Template_ListAllOrganisation_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -45,7 +48,8 @@ export function Template_ListAllOrganisation_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -53,7 +57,9 @@ export function Template_ListAllOrganisation_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            onClick: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_ListAllProcesses_Model.mjs
+++ b/generics/components/templates/Template_ListAllProcesses_Model.mjs
@@ -21,7 +21,8 @@ export function Template_ListAllProcesses_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1.text,
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -29,7 +30,8 @@ export function Template_ListAllProcesses_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -37,7 +39,8 @@ export function Template_ListAllProcesses_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -45,7 +48,8 @@ export function Template_ListAllProcesses_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -53,7 +57,9 @@ export function Template_ListAllProcesses_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            onClick: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -21,7 +21,8 @@ export function Template_Projects_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1.text,
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -29,7 +30,8 @@ export function Template_Projects_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -37,7 +39,8 @@ export function Template_Projects_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -45,7 +48,8 @@ export function Template_Projects_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -53,7 +57,9 @@ export function Template_Projects_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            onClick: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -21,7 +21,8 @@ export function Template_SearchResult_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1.text,
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -29,7 +30,8 @@ export function Template_SearchResult_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -37,7 +39,8 @@ export function Template_SearchResult_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -45,7 +48,8 @@ export function Template_SearchResult_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -53,7 +57,9 @@ export function Template_SearchResult_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            onClick: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -21,8 +21,8 @@ export function Template_Search_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1,
-                            route: model.route
+                            text : model.link1.text,
+                            route: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -21,7 +21,8 @@ export function Template_Search_Model(model) {
                             icon : model.icon1
                         },
                         atom_link : {
-                            text : model.link1
+                            text : model.link1,
+                            route: model.route
                         }
                     },
                     molecule_iconAndLink2 : {

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -30,7 +30,8 @@ export function Template_Search_Model(model) {
                             icon : model.icon2
                         },
                         atom_link : {
-                            text : model.link2
+                            text : model.link2.text,
+                            route: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -38,7 +39,8 @@ export function Template_Search_Model(model) {
                             icon : model.icon3
                         },
                         atom_link : {
-                            text : model.link3
+                            text : model.link3.text,
+                            route: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -46,7 +48,8 @@ export function Template_Search_Model(model) {
                             icon : model.icon4
                         },
                         atom_link : {
-                            text : model.link4
+                            text : model.link4.text,
+                            route: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -54,7 +57,9 @@ export function Template_Search_Model(model) {
                             icon : model.icon5
                         },
                         atom_link : {
-                            text : model.link5
+                            text : model.link5.text,
+                            route: model.link5.onClick
+                            
                         }
                     },
                     molecule_textAndButton : {

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -22,7 +22,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link1.text,
-                            route: model.link1.onClick
+                            onClick: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -31,7 +31,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link2.text,
-                            route: model.link2.onClick
+                            onClick: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {
@@ -40,7 +40,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link3.text,
-                            route: model.link3.onClick
+                            onClick: model.link3.onClick
                         }
                     },
                     molecule_iconAndLink4 : {
@@ -49,7 +49,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link4.text,
-                            route: model.link4.onClick
+                            onClick: model.link4.onClick
                         }
                     },
                     molecule_iconAndLink5 : {
@@ -58,7 +58,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link5.text,
-                            route: model.link5.onClick
+                            onClick: model.link5.onClick
                             
                         }
                     },

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -22,7 +22,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link1.text,
-                            route: model.link1.onClick
+                            route: model.link1.route
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -31,7 +31,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link2.text,
-                            route: model.link2.onClick
+                            route: model.link2.route
                         }
                     },
                     molecule_iconAndLink3 : {

--- a/generics/components/templates/Template_Search_Model.mjs
+++ b/generics/components/templates/Template_Search_Model.mjs
@@ -22,7 +22,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link1.text,
-                            route: model.link1.route
+                            route: model.link1.onClick
                         }
                     },
                     molecule_iconAndLink2 : {
@@ -31,7 +31,7 @@ export function Template_Search_Model(model) {
                         },
                         atom_link : {
                             text : model.link2.text,
-                            route: model.link2.route
+                            route: model.link2.onClick
                         }
                     },
                     molecule_iconAndLink3 : {

--- a/generics/components/templates/Template_Search_View.mjs
+++ b/generics/components/templates/Template_Search_View.mjs
@@ -4,6 +4,7 @@ import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Headin
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 
+
 export function Template_Search_View(view){
     
     Component.call(this)

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -65,8 +65,12 @@
 
 .molecule_text_and_btn {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: center;
     padding: 1em;
+    gap: 30px;
+    justify-content: end;
+    margin-right: 3em;
+
 }
 .molecule_text_and_btn > p{
     padding: 0 !important;

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -85,6 +85,7 @@
     font-weight: bolder;
     color: red;
     font-family: 'Times New Roman', Times, serif;
+    font-size: xx-large;
 }
 
 .molecule_icon_and_link > a {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -81,12 +81,12 @@
     align-self: center;
 }
 
-.molecule_icon_and_link > a:active {
+/* .molecule_icon_and_link > a:active {
     font-weight: bolder;
     color: red;
     font-family: 'Times New Roman', Times, serif;
     font-size: xx-large;
-}
+} */
 
 .molecule_icon_and_link > a {
     color: black;
@@ -94,5 +94,8 @@
    
 }
 nav > ul > div > a {
-   
+    font-weight: bolder;
+    color: red;
+    font-family: 'Times New Roman', Times, serif;
+    font-size: xx-large;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -81,7 +81,7 @@
     align-self: center;
 }
 
-.molecule_icon_and_link > a:focus {
+.molecule_icon_and_link > a:focus-visible {
     font-weight: bolder;
     color: red;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -74,6 +74,7 @@
 }
 .molecule_text_and_btn > p{
     padding: 0 !important;
+    cursor: pointer;
 
 }
 

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -81,9 +81,10 @@
     align-self: center;
 }
 
-.molecule_icon_and_link > a:focus-visible {
+.molecule_icon_and_link > a:focus {
     font-weight: bolder;
     color: red;
+    font-family: 'Times New Roman', Times, serif;
 }
 
 .molecule_icon_and_link > a {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -80,3 +80,8 @@
 .molecule_text_and_btn > button{
     align-self: center;
 }
+
+.molecule_icon_and_link > a:focus {
+    font-weight: bolder;
+    color: red;
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -81,21 +81,15 @@
     align-self: center;
 }
 
-/* .molecule_icon_and_link > a:active {
-    font-weight: bolder;
-    color: red;
-    font-family: 'Times New Roman', Times, serif;
-    font-size: xx-large;
-} */
+.molecule_icon_and_link > a:active {
+    font-weight: bold;
+}
 
 .molecule_icon_and_link > a {
     color: black;
     cursor: pointer;
    
 }
-nav > ul > div > a:active {
-    font-weight: bolder;
-    color: red;
-    font-family: 'Times New Roman', Times, serif;
-    font-size: xx-large;
-}
+/* nav > ul > div > a:active {
+    font-weight: bold;
+} */

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -90,6 +90,3 @@
     cursor: pointer;
    
 }
-/* nav > ul > div > a:active {
-    font-weight: bold;
-} */

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -93,7 +93,7 @@
     cursor: pointer;
    
 }
-nav > ul > div > a {
+nav > ul > div > a:active {
     font-weight: bolder;
     color: red;
     font-family: 'Times New Roman', Times, serif;

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -81,7 +81,7 @@
     align-self: center;
 }
 
-.molecule_icon_and_link > a:focus {
+.molecule_icon_and_link > a:active {
     font-weight: bolder;
     color: red;
     font-family: 'Times New Roman', Times, serif;

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -85,3 +85,12 @@
     font-weight: bolder;
     color: red;
 }
+
+.molecule_icon_and_link > a {
+    color: black;
+    cursor: pointer;
+   
+}
+nav > ul > div > a {
+   
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -70,16 +70,16 @@
     gap: 30px;
     justify-content: end;
     margin-right: 3em;
-
 }
+
 .molecule_text_and_btn > p{
     padding: 0 !important;
     cursor: pointer;
-
 }
 
 .molecule_text_and_btn > button{
     align-self: center;
+    cursor: pointer;
 }
 
 .molecule_icon_and_link > a:active {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -22,7 +22,7 @@ nav > ul > div > a {
    
 }
 
-nav > ul > div > a:active {
+a:active {
     font-weight: bolder;
     color: red;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -29,7 +29,7 @@ nav > ul {
     display: flex;
     padding: 1em;
     justify-content: center;
-    gap: 16xpx;
+    gap: 16px;
     width: 545px;
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -16,12 +16,6 @@ nav {
     height: 75px;
 }
 
-nav > ul > div > a {
-    color: black;
-    cursor: pointer;
-   
-}
-
 nav > ul {
     display: flex;
     padding: 1em;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -22,7 +22,7 @@ nav > ul > div > a {
    
 }
 
-a:focus {
+nav > ul > div > a:focus {
     font-weight: bolder;
     color: red;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -22,11 +22,6 @@ nav > ul > div > a {
    
 }
 
-nav > ul > div > a:focus {
-    font-weight: bolder;
-    color: red;
-}
-
 nav > ul {
     display: flex;
     padding: 1em;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -24,8 +24,6 @@ nav > ul > div > a {
 
 a:active {
     font-weight: bolder;
-    color: red;
-    font-size: large;
 }
 
 nav > ul {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -24,9 +24,7 @@ nav > ul > div > a {
 
 a:focus {
     font-weight: bolder;
-}
-nav > ul > div > a--active {
-    font-weight: bold;
+    color: red;
 }
 
 nav > ul {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -29,8 +29,7 @@ nav > ul {
     display: flex;
     padding: 1em;
     justify-content: center;
-    gap: 16px;
-    width: 545px;
+    gap: 14px;
 }
 
 .organism_form_4_dropdowns {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -25,6 +25,7 @@ nav > ul > div > a {
 a:active {
     font-weight: bolder;
     color: red;
+    font-size: large;
 }
 
 nav > ul {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -18,10 +18,11 @@ nav {
 
 nav > ul > div > a {
     color: black;
+    cursor: pointer;
    
 }
 
-a:active {
+nav > ul > div > a:active {
     font-weight: bold;
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -22,8 +22,11 @@ nav > ul > div > a {
    
 }
 
-a:active {
+a:focus {
     font-weight: bolder;
+}
+nav > ul > div > a--active {
+    font-weight: bold;
 }
 
 nav > ul {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -23,7 +23,8 @@ nav > ul > div > a {
 }
 
 nav > ul > div > a:active {
-    font-weight: bold;
+    font-weight: bolder;
+    color: red;
 }
 
 nav > ul {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -18,12 +18,19 @@ nav {
 
 nav > ul > div > a {
     color: black;
+   
+}
+
+a:active {
+    font-weight: bold;
 }
 
 nav > ul {
     display: flex;
     padding: 1em;
     justify-content: center;
+    gap: 16xpx;
+    width: 545px;
 }
 
 .organism_form_4_dropdowns {


### PR DESCRIPTION
UC-95-change-navbar-according-to-mockup-without-modal


## Description & motivation

Changing the navbar according to mockup:
- adding pointers to links, username and button
- adding gaps to match mockups
- highlighting links when switching views. Note! Is only visible when clicked and dissappears when button is released. 



## How to test

changes are visible to paths: /search, /searchresult, /projects /process, /organisation, /information



## New tickets to be added

The ticket is done if the active link doesn't need to remain bold after it has been clicked on. 


---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
