### PR TITLE
Uc 100 add modal to information to search result view

### DIFF
--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -2,6 +2,8 @@ import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+import { Modal } from "../organisms/Modal.mjs"
+import { Paragraph } from "../atoms/Paragraph.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -21,6 +23,10 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
+                <div class="modal">
+                  ${slot("new-modal")}
+                </div>
+
         </div>
       `;
   };
@@ -33,6 +39,8 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+
+    
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       // document.querySelectorAll('.modal')[0].remove()
@@ -41,6 +49,12 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
+      // document.querySelectorAll('.modal')[0].add()
+
+      this.modal = new Modal(
+        this.paragrap = new Paragraph('testing')
+      )
+      this.fillSlot("new-modal", this.modal.getElement());
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -6,7 +6,7 @@ export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
 
   this.content = model.content;
-  this.modal = null;
+  this.modal = this;
 
   this.getHtml = function () {
     return `
@@ -27,9 +27,15 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     
-    this.getElement().querySelector(".bi-x").addEventListener("click", () => {
-      document.querySelectorAll('.modal')[0].remove()
+    this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+      if(e.target === this.getElement()){
+        this.getElement().remove
+      }
+      // document.querySelectorAll('.modal')[0].remove()
       });
-    
   };
+
+  this.show = function() {
+    document.body.append(this.getElement())
+  }
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -5,6 +5,7 @@ import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 import { Modal } from "../organisms/Modal.mjs"
 import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
 import { Paragraph } from "../atoms/Paragraph.mjs"
+import { Organism_AddToProject } from "../organisms"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -57,9 +58,9 @@ export function Molecule_ModalSearchResultDetail(model) {
       `
       
       this.modal = new Modal_SearchResultDetail(
-        this.paragraph = new Paragraph("testing")
+        this.paragraph = new Organism_AddToProject()
       )
-      
+
       this.fillSlot("new-modal", this.modal.getElement());
       });
 

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -42,7 +42,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.getElement().querySelector(".btn-project").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      this.content = new Molecule_ModalFrame(model.content)
+      new Molecule_ModalFrame(model.content)
 
       });
   };

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -2,6 +2,7 @@ import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+import { Modal} from "../organisms/Modal.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -41,6 +42,8 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.getElement().querySelector(".btn-project").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
+      this.content = new Modal()
+
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -13,14 +13,6 @@ export function Molecule_ModalSearchResultDetail(model) {
 
   this.getHtml = function () {
 
-    // let modal1 = ""
-    
-    // for (let listIndex in model.lists){
-    //     modal1 += `
-    //     ${slot('list' + listIndex)}
-    //     `
-    // }
-
     return `
         <div class="modal-container modal-search-res-det">
                 <div class="modal-title-section">
@@ -36,8 +28,6 @@ export function Molecule_ModalSearchResultDetail(model) {
         </div>
       `;
   };
-
-  // ${slot("new-modal")}
  
   this.bindScript = function () {
 
@@ -60,9 +50,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       const modalId = document.getElementById('modal-id')
 
       modalId.innerHTML = `
-        <div>
           ${slot("new-modal")}
-        </div>
       `
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -39,23 +39,24 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
-    this.fillSlot("new-modal", this.modal.getElement());
 
-    
+
+ 
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       // document.querySelectorAll('.modal')[0].remove()
       console.log('cross button pressed')
       });
 
-    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-      console.log('btn-project button pressed')
-      // document.querySelectorAll('.modal')[0].add()
+    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", addModal)
 
-      this.modal = new Modal(
-        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-      )
-      // this.fillSlot("new-modal", this.modal.getElement());
-      });
+      function addModal() {
+        console.log('btn-project button pressed')
+        
+        this.modal = new Modal(
+          this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+        )
+        this.fillSlot("new-modal", this.modal.getElement());
+      };
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -39,6 +39,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+    this.fillSlot("new-modal", this.modal.getElement());
 
 
  
@@ -52,11 +53,10 @@ export function Molecule_ModalSearchResultDetail(model) {
 
       function addModal() {
         console.log('btn-project button pressed')
-        
+
         this.modal = new Modal(
           this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
         )
-        this.fillSlot("new-modal", this.modal.getElement());
       };
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -14,7 +14,7 @@ export function Molecule_ModalSearchResultDetail(model) {
   this.getHtml = function () {
 
     // let modal1 = ""
-    let modal1 = this.fillSlot("new-modal", this.modal.getElement())
+    
     // for (let listIndex in model.lists){
     //     modal1 += `
     //     ${slot('list' + listIndex)}
@@ -32,10 +32,7 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div class="modal">
-                  
-                  ${modal1}
-                </div>
+                <div id="modal-id" class="modal"></div>
         </div>
       `;
   };
@@ -44,7 +41,7 @@ export function Molecule_ModalSearchResultDetail(model) {
  
   this.bindScript = function () {
 
-    
+    let modal1 = this.fillSlot("new-modal", this.modal.getElement())
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
@@ -62,12 +59,17 @@ export function Molecule_ModalSearchResultDetail(model) {
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
       // document.querySelectorAll('.modal')[0].add()
-      
+      const modalId = document.getElementById('modal-id')
+
+      modalId.innerHTML = `
+        <div>
+          ${slot("new-modal")}
+        </div>
+      `
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
-      
-      // this.fillSlot("new-modal", this.modal.getElement());
+      this.fillSlot("new-modal", this.modal.getElement());
       });
   };
   

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -13,14 +13,10 @@ export function Molecule_ModalSearchResultDetail(model) {
         <div class="modal-container">
                 <div class="modal-title-section">
                     <div class="upper-section">
-                        <h4 class="modal-title">${model.title}</h4>
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 
-                <hr>
                     ${slot("content")}
-                  
-                <hr>
         </div>
       `;
   };

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -44,19 +44,24 @@ export function Molecule_ModalSearchResultDetail(model) {
       console.log('cross button pressed')
     });
 
+
+
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      // document.querySelectorAll('.modal')[0].add()
+
       const modalId = document.getElementById('modal-id')
 
       modalId.innerHTML = `
           ${slot("new-modal")}
       `
+      
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
       this.fillSlot("new-modal", this.modal.getElement());
       });
+
+
   };
   
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -41,8 +41,6 @@ export function Molecule_ModalSearchResultDetail(model) {
  
   this.bindScript = function () {
 
-    let modal1 = this.fillSlot("new-modal", this.modal.getElement())
-
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
     let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -2,7 +2,6 @@ import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Modal } from "../organisms/Modal.mjs"
 import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
 import { Organism_AddToProject } from "../organisms/Organism_AddToProject.mjs"
 
@@ -39,16 +38,11 @@ export function Molecule_ModalSearchResultDetail(model) {
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
-    
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       document.querySelectorAll('.modal-container')[0].remove()
-      console.log('cross button pressed')
     });
 
-
-
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-      console.log('btn-project button pressed')
 
       const modalId = document.getElementById('modal-id')
 
@@ -62,8 +56,6 @@ export function Molecule_ModalSearchResultDetail(model) {
 
       this.fillSlot("new-modal", this.modal.getElement());
       });
-
-
   };
-  
+
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,18 +23,13 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-               
-
+                <div class="modal">
+                  ${slot("new-modal")}
+                </div>
         </div>
       `;
   };
-
-//   <div class="modal">
-//   ${slot("new-modal")}
-// </div>
-
  
-  
   this.bindScript = function () {
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -39,26 +39,22 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+
     
-
-
- 
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       // document.querySelectorAll('.modal')[0].remove()
       console.log('cross button pressed')
       });
 
-    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", addModal)
+    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+      console.log('btn-project button pressed')
+      // document.querySelectorAll('.modal')[0].add()
 
-      function addModal() {
-        console.log('btn-project button pressed')
-
-        this.modal = new Modal(
-          this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-        )
-      };
-      
-    this.fillSlot("new-modal", this.modal.getElement());
+      this.modal = new Modal(
+        this.paragrap = new Paragraph("testing")
+      )
+      this.fillSlot("new-modal", this.modal.getElement());
+      });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -2,7 +2,7 @@ import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Modal} from "../organisms/Modal.mjs"
+import { Molecule_ModalFrame } from "../molecules/Molecule_ModalFrame.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -42,7 +42,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.getElement().querySelector(".btn-project").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      this.content = new Modal()
+      this.content = new Molecule_ModalFrame(model.content)
 
       });
   };

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -8,7 +8,7 @@ export function Molecule_ModalSearchResultDetail(model) {
   this.content = model.content;
   this.modal = null;
 
-  this.primary = model.primaryButton
+//   this.primary = model.primaryButton
 
   this.getHtml = function () {
     return `
@@ -23,9 +23,6 @@ export function Molecule_ModalSearchResultDetail(model) {
                     ${slot("content")}
                   
                 <hr>
-                    <div class="btn-container">
-                      ${slot("primary")}
-                    </div>
         </div>
       `;
   };
@@ -34,15 +31,15 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
-    this.fillSlot("primary", this.primary.getElement());
+    // this.fillSlot("primary", this.primary.getElement());
     this.fillSlot("content", this.content.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", () => {
       document.querySelectorAll('.modal')[0].remove()
       });
       
-    this.primary.getElement().addEventListener("click", () => {
-      document.querySelectorAll('.modal')[0].remove()
-    });
+    // this.primary.getElement().addEventListener("click", () => {
+    //   document.querySelectorAll('.modal')[0].remove()
+    // });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -29,9 +29,10 @@ export function Molecule_ModalSearchResultDetail(model) {
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       if(e.target === this.getElement()){
-        this.getElement().remove
+        // this.getElement().remove
+        document.querySelectorAll('.modal')[0].remove()
       }
-      // document.querySelectorAll('.modal')[0].remove()
+      
       });
   };
 

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -13,22 +13,27 @@ export function Molecule_ModalSearchResultDetail(model) {
         <div class="modal-container">
                 <div class="modal-title-section">
                     <div class="upper-section">
+                        <h4 class="modal-title">${model.title}</h4>
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 
+                <hr>
                     ${slot("content")}
+                  
+                <hr>
         </div>
       `;
   };
   
   this.bindScript = function () {
 
-    this.content = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
+    this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
     this.fillSlot("content", this.content.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", () => {
       document.querySelectorAll('.modal')[0].remove()
       });
+    
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -4,8 +4,7 @@ import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultD
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 import { Modal } from "../organisms/Modal.mjs"
 import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
-import { Paragraph } from "../atoms/Paragraph.mjs"
-import { Organism_AddToProject } from "../organisms"
+import { Organism_AddToProject } from "../organisms/Organism_AddToProject.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -58,7 +57,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       `
       
       this.modal = new Modal_SearchResultDetail(
-        this.paragraph = new Organism_AddToProject()
+        this.modal = new Organism_AddToProject(model.organism_addToProject)
       )
 
       this.fillSlot("new-modal", this.modal.getElement());

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -27,8 +27,9 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     
-    this.getElement().querySelector(".bi-x").addEventListener("click", () => {
-      document.querySelectorAll('.modal')[0].remove()
+    this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+      // document.querySelectorAll('.modal')[0].remove()
+      console.log('cross button pressed')
       });
     
   };

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -51,7 +51,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      document.querySelectorAll('.modal')[0].add()
+      // document.querySelectorAll('.modal')[0].add()
       
       this.modal = new Modal(
         this.paragraph = new Paragraph("testing")

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -53,7 +53,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       // document.querySelectorAll('.modal')[0].add()
 
       this.modal = new Modal(
-        this.paragrap = new Paragraph("testing")
+        this.paragraph = new Paragraph("testing")
       )
       // this.fillSlot("new-modal", this.modal.getElement());
       });

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -8,38 +8,27 @@ export function Molecule_ModalSearchResultDetail(model) {
   this.content = model.content;
   this.modal = null;
 
-//   this.primary = model.primaryButton
-
   this.getHtml = function () {
     return `
         <div class="modal-container">
                 <div class="modal-title-section">
                     <div class="upper-section">
-                        <h4 class="modal-title">${model.title}</h4>
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 
-                <hr>
                     ${slot("content")}
-                  
-                <hr>
         </div>
       `;
   };
   
   this.bindScript = function () {
 
-    this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+    this.content = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
-    // this.fillSlot("primary", this.primary.getElement());
     this.fillSlot("content", this.content.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", () => {
       document.querySelectorAll('.modal')[0].remove()
       });
-      
-    // this.primary.getElement().addEventListener("click", () => {
-    //   document.querySelectorAll('.modal')[0].remove()
-    // });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,13 +23,15 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div class="modal">
-                  ${slot("new-modal")}
-                </div>
+                
 
         </div>
       `;
   };
+
+  // <div class="modal">
+  //                 ${slot("new-modal")}
+  //               </div>
 
  
   
@@ -56,7 +58,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
-      this.fillSlot("new-modal", this.modal.getElement());
+      // this.fillSlot("new-modal", this.modal.getElement());
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -39,6 +39,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+    this.fillSlot("new-modal", this.modal.getElement());
 
     
     
@@ -54,7 +55,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
-      this.fillSlot("new-modal", this.modal.getElement());
+      // this.fillSlot("new-modal", this.modal.getElement());
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -39,7 +39,7 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
-    this.fillSlot("new-modal", this.modal.getElement());
+    
 
 
  
@@ -58,5 +58,7 @@ export function Molecule_ModalSearchResultDetail(model) {
           this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
         )
       };
+      
+    this.fillSlot("new-modal", this.modal.getElement());
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,13 +23,15 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div class="modal">
-                  ${slot("new-modal")}
-                </div>
+               
 
         </div>
       `;
   };
+
+//   <div class="modal">
+//   ${slot("new-modal")}
+// </div>
 
  
   
@@ -46,7 +48,7 @@ export function Molecule_ModalSearchResultDetail(model) {
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       document.querySelectorAll('.modal-container')[0].remove()
       console.log('cross button pressed')
-      });
+    });
 
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -3,6 +3,7 @@ import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 import { Modal } from "../organisms/Modal.mjs"
+import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
 import { Paragraph } from "../atoms/Paragraph.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
@@ -55,9 +56,10 @@ export function Molecule_ModalSearchResultDetail(model) {
           ${slot("new-modal")}
       `
       
-      this.modal = new Modal(
-        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+      this.modal = new Modal_SearchResultDetail(
+        this.paragraph = new Paragraph("testing")
       )
+      
       this.fillSlot("new-modal", this.modal.getElement());
       });
 

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -1,6 +1,7 @@
 import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -17,6 +18,9 @@ export function Molecule_ModalSearchResultDetail(model) {
                     </div>
                 </div> 
                     ${slot("content")}
+                <div class="btn-project">
+                    ${slot("btn-project")}
+                </div>
         </div>
       `;
   };
@@ -25,12 +29,18 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
+    let button = new Atom_ButtonPositive(model.atom_button)
+
     this.fillSlot("content", this.content.getElement());
+    this.fillSlot("btn-project", button.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       // document.querySelectorAll('.modal')[0].remove()
       console.log('cross button pressed')
       });
-    
+
+    this.getElement().querySelector(".btn-project").addEventListener("click", (e) => {
+      console.log('btn-project button pressed')
+      });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -52,7 +52,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       // document.querySelectorAll('.modal')[0].add()
 
       this.modal = new Modal(
-        this.paragrap = new Paragraph('testing')
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
       this.fillSlot("new-modal", this.modal.getElement());
       });

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -12,6 +12,15 @@ export function Molecule_ModalSearchResultDetail(model) {
   this.modal = null;
 
   this.getHtml = function () {
+
+    // let modal1 = ""
+    let modal1 = this.fillSlot("new-modal", this.modal.getElement())
+    // for (let listIndex in model.lists){
+    //     modal1 += `
+    //     ${slot('list' + listIndex)}
+    //     `
+    // }
+
     return `
         <div class="modal-container modal-search-res-det">
                 <div class="modal-title-section">
@@ -24,13 +33,18 @@ export function Molecule_ModalSearchResultDetail(model) {
                     ${slot("atom_btnPositive")}
                 </div>
                 <div class="modal">
-                  ${slot("new-modal")}
+                  
+                  ${modal1}
                 </div>
         </div>
       `;
   };
+
+  // ${slot("new-modal")}
  
   this.bindScript = function () {
+
+    
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
@@ -52,7 +66,8 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
-      this.fillSlot("new-modal", this.modal.getElement());
+      
+      // this.fillSlot("new-modal", this.modal.getElement());
       });
   };
   

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -54,7 +54,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       // document.querySelectorAll('.modal')[0].add()
       
       this.modal = new Modal(
-        this.paragraph = new Paragraph("testing")
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
       this.fillSlot("new-modal", this.modal.getElement());
       });

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -1,0 +1,47 @@
+import { Component } from "nd_frontend/core/Component.mjs";
+import { slot } from "nd_frontend/core/helpers.mjs";
+
+export function Molecule_ModalSearchResultDetail(model) {
+  Component.call(this);
+
+  this.content = model.content;
+  this.modal = null;
+
+  this.primary = model.primaryButton
+  this.secondary = model.secondaryButton
+
+  this.getHtml = function () {
+    return `
+        <div class="modal-container">
+                <div class="modal-title-section">
+                    <div class="upper-section">
+                        <h4 class="modal-title">${model.title}</h4>
+                        <i class="bi bi-x"></i>
+                    </div>
+                </div> 
+                <hr>
+                    ${slot("content")}
+                  
+                <hr>
+                    <div class="btn-container">
+                      ${slot("primary")}
+                      ${slot("secondary")}
+                    </div>
+        </div>
+      `;
+  };
+  
+  this.bindScript = function () {
+    this.fillSlot("primary", this.primary.getElement());
+    this.fillSlot("secondary", this.secondary.getElement());
+    this.fillSlot("content", this.content.getElement());
+    
+    this.getElement().querySelector(".bi-x").addEventListener("click", () => {
+      document.querySelectorAll('.modal')[0].remove()
+      });
+      
+    this.primary.getElement().addEventListener("click", () => {
+      document.querySelectorAll('.modal')[0].remove()
+    });
+  };
+}

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -6,7 +6,7 @@ export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
 
   this.content = model.content;
-  this.modal = this;
+  this.modal = null;
 
   this.getHtml = function () {
     return `
@@ -29,6 +29,7 @@ export function Molecule_ModalSearchResultDetail(model) {
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       if(e.target === this.getElement()){
+        console.log('pressing button')
         // this.getElement().remove
         document.querySelectorAll('.modal')[0].remove()
       }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,13 +23,14 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div class="modal">
-                  ${slot("new-modal")}
-                </div>
 
         </div>
       `;
   };
+
+  // <div class="modal">
+  //                 ${slot("new-modal")}
+  //               </div>
   
   this.bindScript = function () {
 
@@ -54,7 +55,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.paragrap = new Paragraph("testing")
       )
-      this.fillSlot("new-modal", this.modal.getElement());
+      // this.fillSlot("new-modal", this.modal.getElement());
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -55,7 +55,7 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.paragraph = new Paragraph("testing")
       )
-      // this.fillSlot("new-modal", this.modal.getElement());
+      this.fillSlot("new-modal", this.modal.getElement());
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -11,9 +11,9 @@ export function Molecule_ModalSearchResultDetail(model) {
 
   this.getHtml = function () {
     return `
-        <div class="modal-container">
+        <div class="modal-container modal-search-res-det">
                 <div class="modal-title-section">
-                    <div class="search-res-det-upper-section">
+                    <div class="modal-search-res-det-upper-section">
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -1,5 +1,6 @@
 import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
+import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -8,7 +9,6 @@ export function Molecule_ModalSearchResultDetail(model) {
   this.modal = null;
 
   this.primary = model.primaryButton
-  this.secondary = model.secondaryButton
 
   this.getHtml = function () {
     return `
@@ -25,15 +25,16 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <hr>
                     <div class="btn-container">
                       ${slot("primary")}
-                      ${slot("secondary")}
                     </div>
         </div>
       `;
   };
   
   this.bindScript = function () {
+
+    this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+
     this.fillSlot("primary", this.primary.getElement());
-    this.fillSlot("secondary", this.secondary.getElement());
     this.fillSlot("content", this.content.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", () => {

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,15 +23,13 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                
+                <div class="modal">
+                  ${slot("new-modal")}
+                </div>
 
         </div>
       `;
   };
-
-  // <div class="modal">
-  //                 ${slot("new-modal")}
-  //               </div>
 
  
   
@@ -45,9 +43,8 @@ export function Molecule_ModalSearchResultDetail(model) {
     this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
     
-    
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-      document.querySelectorAll('.modal')[0].remove()
+      document.querySelectorAll('.modal-container')[0].remove()
       console.log('cross button pressed')
       });
 
@@ -58,7 +55,8 @@ export function Molecule_ModalSearchResultDetail(model) {
       this.modal = new Modal(
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
       )
-      // this.fillSlot("new-modal", this.modal.getElement());
+      this.fillSlot("new-modal", this.modal.getElement());
       });
   };
+  
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -2,7 +2,6 @@ import { Component } from "nd_frontend/core/Component.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Molecule_ModalFrame } from "../molecules/Molecule_ModalFrame.mjs"
 
 export function Molecule_ModalSearchResultDetail(model) {
   Component.call(this);
@@ -19,8 +18,8 @@ export function Molecule_ModalSearchResultDetail(model) {
                     </div>
                 </div> 
                     ${slot("content")}
-                <div class="btn-project">
-                    ${slot("btn-project")}
+                <div class="org_searh_res_det_btn">
+                    ${slot("atom_btnPositive")}
                 </div>
         </div>
       `;
@@ -30,20 +29,18 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
-    let button = new Atom_ButtonPositive(model.atom_button)
+    let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
 
     this.fillSlot("content", this.content.getElement());
-    this.fillSlot("btn-project", button.getElement());
+    this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
       // document.querySelectorAll('.modal')[0].remove()
       console.log('cross button pressed')
       });
 
-    this.getElement().querySelector(".btn-project").addEventListener("click", (e) => {
+    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      new Molecule_ModalFrame(model.content)
-
       });
   };
 }

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -23,14 +23,15 @@ export function Molecule_ModalSearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
+                <div class="modal">
+                  ${slot("new-modal")}
+                </div>
 
         </div>
       `;
   };
 
-  // <div class="modal">
-  //                 ${slot("new-modal")}
-  //               </div>
+ 
   
   this.bindScript = function () {
 
@@ -44,14 +45,14 @@ export function Molecule_ModalSearchResultDetail(model) {
     
     
     this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-      // document.querySelectorAll('.modal')[0].remove()
+      document.querySelectorAll('.modal')[0].remove()
       console.log('cross button pressed')
       });
 
     this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
       console.log('btn-project button pressed')
-      // document.querySelectorAll('.modal')[0].add()
-
+      document.querySelectorAll('.modal')[0].add()
+      
       this.modal = new Modal(
         this.paragraph = new Paragraph("testing")
       )

--- a/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
+++ b/generics/components/molecules/Molecule_ModalSearchResultDetail.mjs
@@ -12,7 +12,7 @@ export function Molecule_ModalSearchResultDetail(model) {
     return `
         <div class="modal-container">
                 <div class="modal-title-section">
-                    <div class="upper-section">
+                    <div class="search-res-det-upper-section">
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 
@@ -27,17 +27,9 @@ export function Molecule_ModalSearchResultDetail(model) {
 
     this.fillSlot("content", this.content.getElement());
     
-    this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-      if(e.target === this.getElement()){
-        console.log('pressing button')
-        // this.getElement().remove
-        document.querySelectorAll('.modal')[0].remove()
-      }
-      
+    this.getElement().querySelector(".bi-x").addEventListener("click", () => {
+      document.querySelectorAll('.modal')[0].remove()
       });
+    
   };
-
-  this.show = function() {
-    document.body.append(this.getElement())
-  }
 }

--- a/generics/components/molecules/Molecule_textAndDropDown.mjs
+++ b/generics/components/molecules/Molecule_textAndDropDown.mjs
@@ -1,0 +1,27 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Text1} from "../atoms/Atom_Text1.mjs";
+import { Atom_Dropdown } from "../atoms/Atom_Dropdown.mjs"
+
+export function Molecule_textAndDropDown(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_text_and_dropdown">
+                ${slot("text")}
+                ${slot("dropdown")}
+            </div>
+        `
+    }
+
+    this.bindScript= function() {
+        let text = new Atom_Text1(model.atom_text1)
+        this.fillSlot("text", text.getElement());
+
+        let dropdown = new Atom_Dropdown(model.atom_dropdown)
+        this.fillSlot("dropdown", dropdown.getElement());
+    }
+
+}

--- a/generics/components/organisms/Modal.mjs
+++ b/generics/components/organisms/Modal.mjs
@@ -9,7 +9,7 @@ export function Modal(content) {
 
     this.getHtml = function() {
         return `
-        <div class="modal">
+        <div id="modal-popUp" class="modal">
                 ${slot("content")}
         </div>
         `

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -44,6 +44,7 @@ export function Modal_SearchResultDetail(model) {
 
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+        this.fillSlot("new-modal", this.modal.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
@@ -65,7 +66,7 @@ export function Modal_SearchResultDetail(model) {
 
             console.log(modalId, "modelId")
             console.log(this.modal, "this.modal")
-            this.fillSlot("new-modal", this.modal.getElement());
+           
         });
 
         const mStyle = this.getElement().style

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -26,7 +26,7 @@ export function Modal_SearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div id="modal-id-second" class="modal"></div>
+                <div id="modal-id-second"></div>
             </div>
         </div>
         

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -39,7 +39,6 @@ export function Modal_SearchResultDetail(model) {
     this.bindScript= function() {
 
         this.fillSlot("content", this.content.getElement())
-        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
@@ -60,7 +59,7 @@ export function Modal_SearchResultDetail(model) {
             }
         })
 
-        
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
         let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -46,7 +46,7 @@ export function Modal_SearchResultDetail(model) {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
             const modalBg = document.getElementById('modal-background')
-            modalBg.style.removeProperty('backgroundColor')
+            modalBg.style.removeProperty('background-color')
 
         });
 

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -10,8 +10,8 @@ export function Modal_SearchResultDetail(model) {
     Component.call(this)
 
     this.content = model.content
-    // this.modal = null;
-    this.content.modal = null;
+    this.modal = null;
+    // this.content.modal = null;
     
 
     // this.content.modal = this;

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -45,10 +45,7 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
+      
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
@@ -68,6 +65,11 @@ export function Modal_SearchResultDetail(model) {
                 this.getElement().remove()
             }
         })
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -1,0 +1,86 @@
+import {slot} from "../../../core/helpers.mjs";
+import {Component} from "../../../core/Component.mjs";
+import { Atom_ButtonPositive} from "../atoms/Atom_ButtonPositive.mjs"
+import { Organism_SearchResultDetail } from "./Organism_SearchResultDetail.mjs";
+import { Modal } from "./Modal.mjs"
+import { Paragraph } from "../atoms/Paragraph.mjs";
+
+
+export function Modal_SearchResultDetail(content) {
+    Component.call(this)
+
+    this.content = content
+    this.content.modal = this;
+
+    this.getHtml = function() {
+        return `
+        <div class="modal">
+            <div class="modal-container modal-search-res-det">
+                <div class="modal-title-section">
+                    <div class="modal-search-res-det-upper-section">
+                        <i class="bi bi-x"></i>
+                    </div>
+                </div> 
+                ${slot("content")}
+                <div class="org_searh_res_det_btn">
+                    ${slot("atom_btnPositive")}
+                </div>
+                <div id="modal-id" class="modal"></div>
+            </div>
+        </div>
+        
+        `
+    }
+
+    this.bindScript= function() {
+
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+
+        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
+
+        this.fillSlot("content", this.content.getElement())
+        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
+
+        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
+      
+            const modalId = document.getElementById('modal-id')
+      
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal(
+              this.paragrap = new Paragraph("Testing")
+            )
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
+
+        const mStyle = this.getElement().style
+        mStyle.position = "absolute"
+        mStyle.width = window.innerWidth + "px"
+        mStyle.height = window.innerHeight + "px"
+        mStyle.top = "0px"
+        mStyle.left = "0px"
+        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        mStyle.display = "flex"
+        mStyle.justifyContent = "center"
+        mStyle.alignItems = "center"
+
+        this.content.getElement().style.backgroundColor = "white"
+
+        this.getElement().addEventListener("click", (e)=>{
+            if(e.target === this.getElement()){
+                this.getElement().remove()
+            }
+        })
+    }
+
+    this.show= function() {
+        document.body.append(this.getElement())
+    }
+}

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -38,17 +38,8 @@ export function Modal_SearchResultDetail(model) {
 
     this.bindScript= function() {
 
-        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-
-        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
-
         this.fillSlot("content", this.content.getElement())
-        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
-
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
@@ -68,6 +59,16 @@ export function Modal_SearchResultDetail(model) {
                 this.getElement().remove()
             }
         })
+
+        
+
+        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
+        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -4,7 +4,6 @@ import { Atom_ButtonPositive} from "../atoms/Atom_ButtonPositive.mjs"
 import { Organism_SearchResultDetail } from "./Organism_SearchResultDetail.mjs";
 import { Modal } from "./Modal.mjs"
 import { Paragraph } from "../atoms/Paragraph.mjs";
-import { Modal_SearchResultDetail } from "../organisms/"
 
 
 export function Modal_SearchResultDetail(model) {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -45,7 +45,24 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
+
+        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
       
+            const modalId = document.getElementById('modal-id')
+      
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal(
+              this.paragrap = new Paragraph("Testing")
+            )
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
@@ -66,24 +83,7 @@ export function Modal_SearchResultDetail(model) {
             }
         })
 
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
-
-        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
       
-            const modalId = document.getElementById('modal-id')
-      
-            modalId.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal(
-              this.paragrap = new Paragraph("Testing")
-            )
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
     }
 
     this.show= function() {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -43,7 +43,6 @@ export function Modal_SearchResultDetail(model) {
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
             
             const modalBg = document.getElementById('modal-background')
             modalBg.style.removeProperty('background-color')
@@ -51,10 +50,8 @@ export function Modal_SearchResultDetail(model) {
         });
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-            console.log('second modal btn-project pressed')
       
             const modalIdSecond = document.getElementById('modal-id-second')
-            console.log(modalIdSecond)
       
             modalIdSecond.innerHTML = `
                 ${slot("second-modal")}

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -6,7 +6,7 @@ import { Modal } from "./Modal.mjs"
 import { Paragraph } from "../atoms/Paragraph.mjs";
 
 
-export function Modal_SearchResultDetail(content) {
+export function Modal_SearchResultDetail(model) {
     Component.call(this)
 
     this.content = content

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -30,7 +30,6 @@ export function Modal_SearchResultDetail(model) {
                     ${slot("atom_btnPositive")}
                 </div>
                 <div id="modal-id-second" class="modal"></div>
-                
             </div>
         </div>
         

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -69,10 +69,8 @@ export function Modal_SearchResultDetail(model) {
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
-        // mStyle.width = window.innerWidth + "px"
         mStyle.width = "100vw"
-        // mStyle.height = window.innerHeight + "px"
-        mStyle.height = "100vh"
+        mStyle.height = window.innerHeight + "px"
         mStyle.top = "0px"
         mStyle.left = "0px"
         mStyle.backgroundColor = "rgba(0,0,0,0.5)"

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -50,20 +50,6 @@ export function Modal_SearchResultDetail(model) {
             console.log('cross button pressed')
         });
 
-        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
-      
-            const modalId = document.getElementById('modal-id')
-      
-            modalId.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal(
-              this.paragrap = new Paragraph("Testing")
-            )
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
-
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
         mStyle.width = window.innerWidth + "px"
@@ -82,6 +68,20 @@ export function Modal_SearchResultDetail(model) {
                 this.getElement().remove()
             }
         })
+
+        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
+      
+            const modalId = document.getElementById('modal-id')
+      
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal(
+              this.paragrap = new Paragraph("Testing")
+            )
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
     }
 
     this.show= function() {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -15,7 +15,7 @@ export function Modal_SearchResultDetail(model) {
 
     this.getHtml = function() {
         return `
-        <div class="modal">
+        <div id="modal-background" class="modal">
             <div class="modal-container modal-search-res-det">
                 <div class="modal-title-section">
                     <div class="modal-search-res-det-upper-section">
@@ -45,6 +45,9 @@ export function Modal_SearchResultDetail(model) {
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
+            const modalBg = document.getElementById('modal-background')
+            modalBg.style.backgroundColor = "white"
+
         });
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -46,7 +46,7 @@ export function Modal_SearchResultDetail(model) {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
             const modalBg = document.getElementById('modal-background')
-            modalBg.removeProperty('background-color')
+            modalBg.style.removeProperty('backgroundColor')
 
         });
 

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -10,7 +10,11 @@ export function Modal_SearchResultDetail(model) {
     Component.call(this)
 
     this.content = model.content
-    this.content.modal = this;
+    // this.modal = null;
+    this.content.modal = null;
+    
+
+    // this.content.modal = this;
 
     this.getHtml = function() {
         return `

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -45,24 +45,25 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
-        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-        //     document.querySelectorAll('.modal-container')[0].remove()
-        //     console.log('cross button pressed')
-        // });
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
 
-        // this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-        //     console.log('btn-project button pressed')
+        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
       
-        //     const modalId = document.getElementById('modal-id')
+            const modalId = document.getElementById('modal-id')
+            console.log(modalId)
       
-        //     modalId.innerHTML = `
-        //         ${slot("new-modal")}
-        //     `
-        //     this.modal = new Modal(
-        //       this.paragraph = new Paragraph("Testing")
-        //     )
-        //     this.fillSlot("new-modal", this.modal.getElement());
-        // });
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal(
+              this.paragraph = new Paragraph("Testing")
+            )
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
@@ -89,23 +90,4 @@ export function Modal_SearchResultDetail(model) {
     this.show= function() {
         document.body.append(this.getElement())
     }
-
-    this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-        document.querySelectorAll('.modal-container')[0].remove()
-        console.log('cross button pressed')
-    });
-
-    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-        console.log('btn-project button pressed')
-  
-        const modalId = document.getElementById('modal-id')
-  
-        modalId.innerHTML = `
-            ${slot("new-modal")}
-        `
-        this.modal = new Modal(
-          this.paragraph = new Paragraph("Testing")
-        )
-        this.fillSlot("new-modal", this.modal.getElement());
-    });
 }

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -38,8 +38,6 @@ export function Modal_SearchResultDetail(model) {
 
     this.bindScript= function() {
 
-        this.fillSlot("content", this.content.getElement())
-
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
         mStyle.width = window.innerWidth + "px"
@@ -62,12 +60,16 @@ export function Modal_SearchResultDetail(model) {
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
         let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
+
+        this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
         });
+
+        
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -59,23 +59,23 @@ export function Modal_SearchResultDetail(model) {
                 ${slot("new-modal")}
             `
             this.modal = new Modal(
-              this.paragrap = new Paragraph("Testing")
+              this.paragraph = new Paragraph("Testing")
             )
             this.fillSlot("new-modal", this.modal.getElement());
         });
 
-        const mStyle = this.getElement().style
-        mStyle.position = "absolute"
-        mStyle.width = window.innerWidth + "px"
-        mStyle.height = window.innerHeight + "px"
-        mStyle.top = "0px"
-        mStyle.left = "0px"
-        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
-        mStyle.display = "flex"
-        mStyle.justifyContent = "center"
-        mStyle.alignItems = "center"
+        // const mStyle = this.getElement().style
+        // mStyle.position = "absolute"
+        // mStyle.width = window.innerWidth + "px"
+        // mStyle.height = window.innerHeight + "px"
+        // mStyle.top = "0px"
+        // mStyle.left = "0px"
+        // mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        // mStyle.display = "flex"
+        // mStyle.justifyContent = "center"
+        // mStyle.alignItems = "center"
 
-        this.content.getElement().style.backgroundColor = "white"
+        // this.content.getElement().style.backgroundColor = "white"
 
         this.getElement().addEventListener("click", (e)=>{
             if(e.target === this.getElement()){

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -46,7 +46,7 @@ export function Modal_SearchResultDetail(model) {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
             const modalBg = document.getElementById('modal-background')
-            modalBg.style.backgroundColor = "white"
+            modalBg.removeProperty('background-color')
 
         });
 

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -43,7 +43,7 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
+            document.querySelector('.modal-container')[0].remove()
             console.log('cross button pressed')
             const modalBg = document.getElementById('modal-background')
             modalBg.style.removeProperty('background-color')
@@ -63,8 +63,6 @@ export function Modal_SearchResultDetail(model) {
               this.content = new Organism_AddToProject(model.organism_addToProject)
             )
 
-            console.log(modalIdSecond, "modelId")
-            console.log(this.modal, "this.modal")
             this.fillSlot("second-modal", this.modal.getElement());
         });
 

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -9,7 +9,7 @@ import { Paragraph } from "../atoms/Paragraph.mjs";
 export function Modal_SearchResultDetail(model) {
     Component.call(this)
 
-    this.content = content
+    this.content = model.content
     this.content.modal = this;
 
     this.getHtml = function() {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -3,7 +3,8 @@ import {Component} from "../../../core/Component.mjs";
 import { Atom_ButtonPositive} from "../atoms/Atom_ButtonPositive.mjs"
 import { Organism_SearchResultDetail } from "./Organism_SearchResultDetail.mjs";
 import { Modal } from "./Modal.mjs"
-import { Paragraph } from "../atoms/Paragraph.mjs";
+import { Organism_AddToProject } from "./Organism_AddToProject.mjs";
+
 
 
 export function Modal_SearchResultDetail(model) {
@@ -11,10 +12,6 @@ export function Modal_SearchResultDetail(model) {
 
     this.content = model.content
     this.modal = null;
-    // this.content.modal = null;
-    
-
-    // this.content.modal = this;
 
     this.getHtml = function() {
         return `
@@ -60,7 +57,7 @@ export function Modal_SearchResultDetail(model) {
                 ${slot("second-modal")}
             `
             this.modal = new Modal(
-              this.paragraph = new Paragraph("Testing")
+              this.content = new Organism_AddToProject(model.organism_addToProject)
             )
 
             console.log(modalIdSecond, "modelId")

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -29,7 +29,8 @@ export function Modal_SearchResultDetail(model) {
                 <div class="org_searh_res_det_btn">
                     ${slot("atom_btnPositive")}
                 </div>
-                <div id="modal-id" class="modal"></div>
+                <div id="modal-id-second" class="modal"></div>
+                
             </div>
         </div>
         
@@ -51,21 +52,21 @@ export function Modal_SearchResultDetail(model) {
         });
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
+            console.log('second modal btn-project pressed')
       
-            const modalId = document.getElementById('modal-id')
-            console.log(modalId)
+            const modalIdSecond = document.getElementById('modal-id-second')
+            console.log(modalIdSecond)
       
-            modalId.innerHTML = `
-                ${slot("new-modal")}
+            modalIdSecond.innerHTML = `
+                ${slot("second-modal")}
             `
             this.modal = new Modal(
               this.paragraph = new Paragraph("Testing")
             )
 
-            console.log(modalId, "modelId")
+            console.log(modalIdSecond, "modelId")
             console.log(this.modal, "this.modal")
-            this.fillSlot("new-modal", this.modal.getElement());
+            this.fillSlot("second-modal", this.modal.getElement());
         });
 
         const mStyle = this.getElement().style

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -67,8 +67,10 @@ export function Modal_SearchResultDetail(model) {
 
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
-        mStyle.width = window.innerWidth + "px"
-        mStyle.height = window.innerHeight + "px"
+        // mStyle.width = window.innerWidth + "px"
+        mStyle.width = "100vw"
+        // mStyle.height = window.innerHeight + "px"
+        mStyle.height = "100vh"
         mStyle.top = "0px"
         mStyle.left = "0px"
         mStyle.backgroundColor = "rgba(0,0,0,0.5)"

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -43,7 +43,7 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('.modal-container')[0].remove()
+            document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
             const modalBg = document.getElementById('modal-background')
             modalBg.style.removeProperty('background-color')

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -36,7 +36,6 @@ export function Modal_SearchResultDetail(model) {
     this.bindScript= function() {
 
         this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-
         let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
 
         this.fillSlot("content", this.content.getElement())
@@ -85,8 +84,6 @@ export function Modal_SearchResultDetail(model) {
                 this.getElement().remove()
             }
         })
-
-      
     }
 
     this.show= function() {

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -45,37 +45,37 @@ export function Modal_SearchResultDetail(model) {
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
 
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
+        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+        //     document.querySelectorAll('.modal-container')[0].remove()
+        //     console.log('cross button pressed')
+        // });
 
-        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
+        // this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+        //     console.log('btn-project button pressed')
       
-            const modalId = document.getElementById('modal-id')
+        //     const modalId = document.getElementById('modal-id')
       
-            modalId.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal(
-              this.paragraph = new Paragraph("Testing")
-            )
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
+        //     modalId.innerHTML = `
+        //         ${slot("new-modal")}
+        //     `
+        //     this.modal = new Modal(
+        //       this.paragraph = new Paragraph("Testing")
+        //     )
+        //     this.fillSlot("new-modal", this.modal.getElement());
+        // });
 
-        // const mStyle = this.getElement().style
-        // mStyle.position = "absolute"
-        // mStyle.width = window.innerWidth + "px"
-        // mStyle.height = window.innerHeight + "px"
-        // mStyle.top = "0px"
-        // mStyle.left = "0px"
-        // mStyle.backgroundColor = "rgba(0,0,0,0.5)"
-        // mStyle.display = "flex"
-        // mStyle.justifyContent = "center"
-        // mStyle.alignItems = "center"
+        const mStyle = this.getElement().style
+        mStyle.position = "absolute"
+        mStyle.width = window.innerWidth + "px"
+        mStyle.height = window.innerHeight + "px"
+        mStyle.top = "0px"
+        mStyle.left = "0px"
+        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        mStyle.display = "flex"
+        mStyle.justifyContent = "center"
+        mStyle.alignItems = "center"
 
-        // this.content.getElement().style.backgroundColor = "white"
+        this.content.getElement().style.backgroundColor = "white"
 
         this.getElement().addEventListener("click", (e)=>{
             if(e.target === this.getElement()){
@@ -89,4 +89,23 @@ export function Modal_SearchResultDetail(model) {
     this.show= function() {
         document.body.append(this.getElement())
     }
+
+    this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+        document.querySelectorAll('.modal-container')[0].remove()
+        console.log('cross button pressed')
+    });
+
+    this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+        console.log('btn-project button pressed')
+  
+        const modalId = document.getElementById('modal-id')
+  
+        modalId.innerHTML = `
+            ${slot("new-modal")}
+        `
+        this.modal = new Modal(
+          this.paragraph = new Paragraph("Testing")
+        )
+        this.fillSlot("new-modal", this.modal.getElement());
+    });
 }

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -44,7 +44,6 @@ export function Modal_SearchResultDetail(model) {
 
         this.fillSlot("content", this.content.getElement())
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
-        this.fillSlot("new-modal", this.modal.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
@@ -66,7 +65,7 @@ export function Modal_SearchResultDetail(model) {
 
             console.log(modalId, "modelId")
             console.log(this.modal, "this.modal")
-           
+            this.fillSlot("new-modal", this.modal.getElement());
         });
 
         const mStyle = this.getElement().style

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -4,6 +4,7 @@ import { Atom_ButtonPositive} from "../atoms/Atom_ButtonPositive.mjs"
 import { Organism_SearchResultDetail } from "./Organism_SearchResultDetail.mjs";
 import { Modal } from "./Modal.mjs"
 import { Paragraph } from "../atoms/Paragraph.mjs";
+import { Modal_SearchResultDetail } from "../organisms/"
 
 
 export function Modal_SearchResultDetail(model) {
@@ -38,6 +39,18 @@ export function Modal_SearchResultDetail(model) {
 
     this.bindScript= function() {
 
+        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+
+        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
+
+        this.fillSlot("content", this.content.getElement())
+        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
+
         const mStyle = this.getElement().style
         mStyle.position = "absolute"
         mStyle.width = window.innerWidth + "px"
@@ -56,20 +69,6 @@ export function Modal_SearchResultDetail(model) {
                 this.getElement().remove()
             }
         })
-
-        this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-
-        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
-
-        this.fillSlot("content", this.content.getElement())
-        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
-
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
-
-        
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -45,6 +45,7 @@ export function Modal_SearchResultDetail(model) {
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
+            
             const modalBg = document.getElementById('modal-background')
             modalBg.style.removeProperty('background-color')
 

--- a/generics/components/organisms/Modal_SearchResultDetail.mjs
+++ b/generics/components/organisms/Modal_SearchResultDetail.mjs
@@ -62,6 +62,9 @@ export function Modal_SearchResultDetail(model) {
             this.modal = new Modal(
               this.paragraph = new Paragraph("Testing")
             )
+
+            console.log(modalId, "modelId")
+            console.log(this.modal, "this.modal")
             this.fillSlot("new-modal", this.modal.getElement());
         });
 

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -1,0 +1,40 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs"
+import { Molecule_textAndDropDown } from "../molecules/Molecule_textAndDropDown.mjs"
+
+export function Organism_AddToProject(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="organism_add-to-proj">
+                ${slot("relProj")}
+                ${slot("relInfo")}
+                ${slot("relProc")}
+                ${slot("relOrg")}
+                <div class="org_add-to-proj-btn">
+                ${slot("button")}
+                <div>
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+        let relProj = new Molecule_textAndDropDown(model.molecule_textAndDropDown1)
+        this.fillSlot("relProj", relProj.getElement());
+
+        let relInfo = new Molecule_textAndDropDown(model.molecule_textAndDropDown2)
+        this.fillSlot("relInfo", relInfo.getElement());
+
+        let relProc = new Molecule_textAndDropDown(model.molecule_textAndDropDown3)
+        this.fillSlot("relProc", relProc.getElement());
+
+        let relOrg = new Molecule_textAndDropDown(model.molecule_textAndDropDown4)
+        this.fillSlot("relOrg", relOrg.getElement());
+
+        let button = new Atom_ButtonPositive(model.atom_buttonPositive)
+        this.fillSlot("button", button.getElement());
+    }
+}

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -50,7 +50,7 @@ export function Organism_AddToProject(model) {
             document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            const x = document.getElementById("modal-addToProj").parentElement.nodeName;
+            const x = document.querySelector("modal-container-second").parentElement.nodeName;
             console.log(x)
         });
     }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal')[1].toggleAttribute()
+            document.querySelectorAll('.modal')[1].remove()
             console.log('cross button pressed')
 
             // const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-org-add-to-proj')[1].remove()
+            document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
             // const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal')[1].remove()
+            document.querySelectorAll('.modal')[1].toggleAttribute()
             console.log('cross button pressed')
 
             // const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -52,10 +52,7 @@ export function Organism_AddToProject(model) {
 
             modalSecond.remove()
 
-            // document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
-
-            // this.parentElement.style.display = 'none'
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -10,7 +10,7 @@ export function Organism_AddToProject(model) {
 
         return `
         <div id="modal-addToProj" class="modal modal-org-add-to-proj">
-            <div class="modal-container modal-add-to-project">
+            <div class="modal-container-second modal-add-to-project">
                 <div class="modal-title-section">
                         <div class="modal-search-res-det-upper-section">
                             <i class="bi bi-x"></i>
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
+            document.querySelector('.modal-container-second')[0].remove()
             console.log('cross button pressed')
 
             const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -9,7 +9,7 @@ export function Organism_AddToProject(model) {
     this.getHtml = function() {
 
         return `
-        <div class="modal">
+        <div id="modal-addToProj" class="modal modal-org-add-to-proj">
             <div class="modal-container modal-add-to-project">
                 <div class="modal-title-section">
                         <div class="modal-search-res-det-upper-section">
@@ -47,8 +47,11 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-add-to-project')[0].remove()
+            document.querySelector('.modal-add-to-project')[0].remove()
             console.log('cross button pressed')
+
+            const modalAddtoProj = document.getElementById('modal-addToProj')
+            modalAddtoProj.style.removeProperty('background-color')
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('.modal-container')[0].remove()
+            document.querySelector('.modal-add-to-project')[0].remove()
             console.log('cross button pressed')
 
             const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
+            document.querySelectorAll('.modal-search-res-det')[0].remove()
             console.log('cross button pressed')
         });
     }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -50,7 +50,7 @@ export function Organism_AddToProject(model) {
             document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            document.querySelectorAll('modal')[0].remove()
+            document.querySelectorAll('modal')[1].remove()
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -51,8 +51,6 @@ export function Organism_AddToProject(model) {
             const modalSecond = document.getElementById("modal-popUp")
 
             modalSecond.remove()
-
-            console.log('cross button pressed')
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -10,7 +10,7 @@ export function Organism_AddToProject(model) {
 
         return `
         <div class="modal">
-            <div class="modal-container modal-search-res-det">
+            <div class="modal-container modal-add-to-project">
                 <div class="modal-title-section">
                         <div class="modal-search-res-det-upper-section">
                             <i class="bi bi-x"></i>
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-search-res-det')[0].remove()
+            document.querySelectorAll('.modal-add-to-project')[0].remove()
             console.log('cross button pressed')
         });
     }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('.modal-container-second')[0].remove()
+            document.querySelectorAll('.modal-container-second')[0].remove()
             console.log('cross button pressed')
 
             const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -9,15 +9,24 @@ export function Organism_AddToProject(model) {
     this.getHtml = function() {
 
         return `
-            <div class="organism_add-to-proj">
-                ${slot("relProj")}
-                ${slot("relInfo")}
-                ${slot("relProc")}
-                ${slot("relOrg")}
-                <div class="org_add-to-proj-btn">
-                ${slot("button")}
-                <div>
+        <div class="modal">
+            <div class="modal-container modal-search-res-det">
+                <div class="modal-title-section">
+                        <div class="modal-search-res-det-upper-section">
+                            <i class="bi bi-x"></i>
+                        </div>
+                </div> 
+                <div class="organism_add-to-proj">
+                    ${slot("relProj")}
+                    ${slot("relInfo")}
+                    ${slot("relProc")}
+                    ${slot("relOrg")}
+                    <div class="org_add-to-proj-btn">
+                    ${slot("button")}
+                    <div>
+                </div>
             </div>
+        </div>
         ` 
     }
 
@@ -36,5 +45,10 @@ export function Organism_AddToProject(model) {
 
         let button = new Atom_ButtonPositive(model.atom_buttonPositive2)
         this.fillSlot("button", button.getElement());
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,10 +47,15 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
+
+            const modalSecond = document.getElementById("modal-id-second")
+
+            modalSecond.remove()
+
+            // document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            this.parentElement.style.display = 'none'
+            // this.parentElement.style.display = 'none'
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('.modal-container')[0].remove()
+            document.querySelectorAll('.modal-container')[0].remove()
             console.log('cross button pressed')
 
             const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -48,7 +48,7 @@ export function Organism_AddToProject(model) {
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
 
-            const modalSecond = document.getElementById("modal-id-second")
+            const modalSecond = document.getElementById("modal-popUp")
 
             modalSecond.remove()
 

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal')[1].remove()
+            document.querySelectorAll('.modal-org-add-to-proj')[1].remove()
             console.log('cross button pressed')
 
             // const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,11 +47,11 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container-second')[0].remove()
+            document.querySelectorAll('.modal')[1].remove()
             console.log('cross button pressed')
 
-            const modalAddtoProj = document.getElementById('modal-addToProj')
-            modalAddtoProj.style.removeProperty('background-color')
+            // const modalAddtoProj = document.getElementById('modal-addToProj')
+            // modalAddtoProj.style.removeProperty('background-color')
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -34,7 +34,7 @@ export function Organism_AddToProject(model) {
         let relOrg = new Molecule_textAndDropDown(model.molecule_textAndDropDown4)
         this.fillSlot("relOrg", relOrg.getElement());
 
-        let button = new Atom_ButtonPositive(model.atom_buttonPositive)
+        let button = new Atom_ButtonPositive(model.atom_buttonPositive2)
         this.fillSlot("button", button.getElement());
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -50,8 +50,8 @@ export function Organism_AddToProject(model) {
             document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            // const modalAddtoProj = document.getElementById('modal-addToProj')
-            // modalAddtoProj.style.removeProperty('background-color')
+            const x = document.getElementById("modal-addToProj").parentElement.nodeName;
+            console.log(x)
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -50,8 +50,7 @@ export function Organism_AddToProject(model) {
             document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            const x = document.querySelector("modal-container-second").parentElement.nodeName;
-            console.log(x)
+            document.querySelectorAll('modal')[0].remove()
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -50,7 +50,7 @@ export function Organism_AddToProject(model) {
             document.querySelectorAll('.modal-org-add-to-proj')[0].remove()
             console.log('cross button pressed')
 
-            document.querySelectorAll('modal')[1].remove()
+            this.parentElement.style.display = 'none'
         });
     }
 }

--- a/generics/components/organisms/Organism_AddToProject.mjs
+++ b/generics/components/organisms/Organism_AddToProject.mjs
@@ -47,7 +47,7 @@ export function Organism_AddToProject(model) {
         this.fillSlot("button", button.getElement());
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('.modal-add-to-project')[0].remove()
+            document.querySelector('.modal-container')[0].remove()
             console.log('cross button pressed')
 
             const modalAddtoProj = document.getElementById('modal-addToProj')

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -11,12 +11,14 @@ export function Organism_SearchResultDetail(model) {
     this.getHtml = function() {
 
         return `
-            <div>
-                <div>
+            <div class="organism_search_result_detail">
+                <div class="organism_search_res_det_top">
                     <div>
                         ${slot("mol_head_text")}
                     </div>
+                    <div class="organism_search_res_det_image">
                         ${slot("atom_image")}
+                    </div>
                 </div>
                 <div>
                     ${slot("listInfo")}
@@ -44,7 +46,7 @@ export function Organism_SearchResultDetail(model) {
         let listOrg = new Molecule_List(model.molecule_list3)
         this.fillSlot("listOrg", listOrg.getElement());
 
-        let atom_btnPositive = new Atom_ButtonPositive(model.molecule_list3)
+        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
         this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
     }
 }

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -25,7 +25,9 @@ export function Organism_SearchResultDetail(model) {
                     ${slot("listProcess")}
                     ${slot("listOrg")}
                 </div>
-                ${slot("atom_btnPositive")}
+                <div class="org_searh_res_det_btn">
+                    ${slot("atom_btnPositive")}
+                <div>
             </div>
         ` 
     }

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -25,9 +25,6 @@ export function Organism_SearchResultDetail(model) {
                     ${slot("listProcess")}
                     ${slot("listOrg")}
                 </div>
-                <div class="org_searh_res_det_btn">
-                    ${slot("atom_btnPositive")}
-                <div>
             </div>
         ` 
     }
@@ -48,7 +45,12 @@ export function Organism_SearchResultDetail(model) {
         let listOrg = new Molecule_List(model.molecule_list3)
         this.fillSlot("listOrg", listOrg.getElement());
 
-        let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
-        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+        // let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
+        // this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
     }
 }
+
+
+// <div class="org_searh_res_det_btn">
+//                     ${slot("atom_btnPositive")}
+//                 <div></div>

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -11,16 +11,16 @@ export function Organism_SearchResultDetail(model) {
     this.getHtml = function() {
 
         return `
-            <div class="organism_search_result_detail">
-                <div class="organism_search_res_det_top">
+            <div class="org_search_result_detail">
+                <div class="org_search_res_det_top">
                     <div>
                         ${slot("mol_head_text")}
                     </div>
-                    <div class="organism_search_res_det_image">
+                    <div class="org_search_res_det_image">
                         ${slot("atom_image")}
                     </div>
                 </div>
-                <div>
+                <div class="org_search_res_det_lists">
                     ${slot("listInfo")}
                     ${slot("listProcess")}
                     ${slot("listOrg")}

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -1,0 +1,50 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Molecule_HeaderAndText } from "../molecules/Molecule_HeaderAndText.mjs"
+import { Atom_Image } from "../atoms/Atom_Image.mjs";
+import { Molecule_List } from "../molecules/Molecule_List.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+
+export function Organism_SearchResultDetail(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div>
+                <div>
+                    <div>
+                        ${slot("mol_head_text")}
+                    </div>
+                        ${slot("atom_image")}
+                </div>
+                <div>
+                    ${slot("listInfo")}
+                    ${slot("listProcess")}
+                    ${slot("listOrg")}
+                </div>
+                ${slot("atom_btnPositive")}
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+        let mol_head_text = new Molecule_HeaderAndText(model.molecule_headerAndText)
+        this.fillSlot("mol_head_text", mol_head_text.getElement());
+
+        let atom_image = new Atom_Image(model.atom_image)
+        this.fillSlot("atom_image", atom_image.getElement());
+
+        let listInfo = new Molecule_List(model.molecule_list1)
+        this.fillSlot("listInfo", listInfo.getElement());
+
+        let listProcess = new Molecule_List(model.molecule_list2)
+        this.fillSlot("listProcess", listProcess.getElement());
+
+        let listOrg = new Molecule_List(model.molecule_list3)
+        this.fillSlot("listOrg", listOrg.getElement());
+
+        let atom_btnPositive = new Atom_ButtonPositive(model.molecule_list3)
+        this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
+    }
+}

--- a/generics/components/organisms/Organism_SearchResultDetail.mjs
+++ b/generics/components/organisms/Organism_SearchResultDetail.mjs
@@ -3,7 +3,6 @@ import {slot} from "../../../core/helpers.mjs";
 import { Molecule_HeaderAndText } from "../molecules/Molecule_HeaderAndText.mjs"
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Molecule_List } from "../molecules/Molecule_List.mjs";
-import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
 export function Organism_SearchResultDetail(model) {
     Component.call(this)
@@ -44,13 +43,5 @@ export function Organism_SearchResultDetail(model) {
 
         let listOrg = new Molecule_List(model.molecule_list3)
         this.fillSlot("listOrg", listOrg.getElement());
-
-        // let atom_btnPositive = new Atom_ButtonPositive(model.atom_buttonPositive)
-        // this.fillSlot("atom_btnPositive", atom_btnPositive.getElement());
     }
 }
-
-
-// <div class="org_searh_res_det_btn">
-//                     ${slot("atom_btnPositive")}
-//                 <div></div>

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -127,6 +127,10 @@ export function Template_SearchResult_Model(model) {
                     atom_buttonPositive : {
                         text: model.buttonPositive.text
                     }
+                },
+                atom_buttonPositive : {
+                    text : model.testButton.text,
+                    onClick : model.testButton.onClick
                 }
             }
         }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -126,11 +126,11 @@ export function Template_SearchResult_Model(model) {
                                 {text: "List item"},
                                 {text: "List item"},
                             ]
-                        },
-                        atom_buttonPositive : {
-                            text: model.buttonPositive.text,
-                            onClick : model.buttonPositive.onClick
                         }
+                    },
+                    atom_buttonPositive : {
+                        text: model.buttonPositive.text,
+                        onClick : model.buttonPositive.onClick
                     }
                 }
             }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -127,10 +127,6 @@ export function Template_SearchResult_Model(model) {
                     atom_buttonPositive : {
                         text: model.buttonPositive.text
                     }
-                },
-                atom_buttonPositive : {
-                    text : model.testButton.text,
-                    onClick : model.testButton.onClick
                 }
             }
         }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -73,61 +73,62 @@ export function Template_SearchResult_Model(model) {
                         onClick : model.button.onClick
                     }
                 },
-                organism_searchResultDetail : {
-                    molecule_headerAndText : {
-                        atom_heading4 : {
-                            text : model.heading
+                content : {
+                    organism_searchResultDetail : {
+                        molecule_headerAndText : {
+                            atom_heading4 : {
+                                text : model.heading
+                            },
+                            atom_text1 : {
+                                text: model.infoText 
+                            }
                         },
-                        atom_text1 : {
-                            text: model.infoText 
+                        atom_image : {
+                            src : model.src,
+                            alt : model.alt
+                        },
+                        molecule_list1 : {
+                            atom_heading4 : {
+                                text : model.listInfo
+                            },
+                            items: [
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                            ]
+                        },
+                        molecule_list2 : {
+                            atom_heading4 : {
+                                text : model.listProcess
+                            },
+                            items: [
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                            ]
+                        },
+                        molecule_list3 : {
+                            atom_heading4 : {
+                                text : model.listOrg
+                            },
+                            items: [
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                                {text: "List item"},
+                            ]
+                        },
+                        atom_buttonPositive : {
+                            text: model.buttonPositive.text,
+                            onClick : model.buttonPositive.onClick
                         }
-                    },
-                    atom_image : {
-                        src : model.src,
-                        alt : model.alt
-                    },
-                    molecule_list1 : {
-                        atom_heading4 : {
-                            text : model.listInfo
-                        },
-                        items: [
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                        ]
-                    },
-                    molecule_list2 : {
-                        atom_heading4 : {
-                            text : model.listProcess
-                        },
-                        items: [
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                        ]
-                    },
-                    molecule_list3 : {
-                        atom_heading4 : {
-                            text : model.listOrg
-                        },
-                        items: [
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                            {text: "List item"},
-                        ]
-                    },
-                    atom_buttonPositive : {
-                        text: model.buttonPositive.text,
-                        onClick : model.buttonPositive.onClick
                     }
                 }
-
             }
         }
 

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -129,8 +129,8 @@ export function Template_SearchResult_Model(model) {
                         }
                     },
                     atom_buttonPositive : {
-                        text: model.buttonPositive.text,
-                        onClick : model.buttonPositive.onClick
+                        text: model.buttonPositive.text
+                        // onClick : model.buttonPositive.onClick
                     }
                 }
             }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -176,7 +176,46 @@ export function Template_SearchResult_Model(model) {
                     },
                     atom_buttonPositive : {
                         text: model.buttonPositive.text
+                    },
+                    organism_addToProject : {
+                        molecule_textAndDropDown1 : {
+                            atom_text1 : {
+                                text : model.projHeader
+                            },
+                            atom_dropdown : {
+                                text : model.dropdown
+                            }
+                        },
+                        molecule_textAndDropDown2 : {
+                            atom_text1 : {
+                                text : model.infoHeader
+                            },
+                            atom_dropdown : {
+                                text : model.dropdown
+                            }
+                        },
+                        molecule_textAndDropDown3 : {
+                            atom_text1 : {
+                                text : model.proHeader
+                            },
+                            atom_dropdown : {
+                                text : model.dropdown
+                            }
+                        },
+                        molecule_textAndDropDown4 : {
+                            atom_text1 : {
+                                text : model.orgHeader
+                            },
+                            atom_dropdown : {
+                                text : model.dropdown
+                            }
+                        },
+                        atom_buttonPositive : {
+                            text : model.buttonPositive.text,
+                            onClick : model.buttonPositive.onClick
+                        }
                     }
+
             }
                 
             }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -74,6 +74,10 @@ export function Template_SearchResult_Model(model) {
                     }
                 },
                 content : {
+                    atom_button :{
+                        text: model.buttonPositive1.text,
+                        onClick : model.buttonPositive.onClick
+                    },
                     organism_searchResultDetail : {
                         molecule_headerAndText : {
                             atom_heading4 : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -212,7 +212,7 @@ export function Template_SearchResult_Model(model) {
                         },
                         atom_buttonPositive2 : {
                             text : model.buttonPositive2.text,
-                            onClick : model.buttonPositive.onClick
+                            onClick : model.buttonPositive2.onClick
                         }
                     }
 

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -76,7 +76,7 @@ export function Template_SearchResult_Model(model) {
                 content : {
                     atom_button :{
                         text: model.buttonPositive1.text,
-                        onClick : model.buttonPositive.onClick
+                        onClick : model.buttonPositive1.onClick
                     },
                     organism_searchResultDetail : {
                         molecule_headerAndText : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -117,11 +117,11 @@ export function Template_SearchResult_Model(model) {
                         text : model.organisationText
                     },
                 },
-            molecule_paginator : {
-                onPageNumberClick : model.paginator.onPageNumberClick, 
-                numberOfPages : model.paginator.numberOfPages,
-                currentPage : model.paginator.currentPage,
-                pageNumberToDisplay : model.paginator.pageNumberToDisplay
+                molecule_paginator : {
+                    onPageNumberClick : model.paginator.onPageNumberClick, 
+                    numberOfPages : model.paginator.numberOfPages,
+                    currentPage : model.paginator.currentPage,
+                    pageNumberToDisplay : model.paginator.pageNumberToDisplay
                 },
                 content : {
                     organism_searchResultDetail : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -73,10 +73,6 @@ export function Template_SearchResult_Model(model) {
                         onClick : model.button.onClick
                     }
                 },
-                atom_button :{
-                    text: model.buttonPositive1.text,
-                    onClick : model.buttonPositive1.onClick
-                },
                 content : {
                     organism_searchResultDetail : {
                         molecule_headerAndText : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -73,11 +73,11 @@ export function Template_SearchResult_Model(model) {
                         onClick : model.button.onClick
                     }
                 },
+                atom_button :{
+                    text: model.buttonPositive1.text,
+                    onClick : model.buttonPositive1.onClick
+                },
                 content : {
-                    atom_button :{
-                        text: model.buttonPositive1.text,
-                        onClick : model.buttonPositive1.onClick
-                    },
                     organism_searchResultDetail : {
                         molecule_headerAndText : {
                             atom_heading4 : {

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -130,7 +130,6 @@ export function Template_SearchResult_Model(model) {
                     },
                     atom_buttonPositive : {
                         text: model.buttonPositive.text
-                        // onClick : model.buttonPositive.onClick
                     }
                 }
             }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -210,8 +210,8 @@ export function Template_SearchResult_Model(model) {
                                 text : model.dropdown
                             }
                         },
-                        atom_buttonPositive : {
-                            text : model.buttonPositive.text,
+                        atom_buttonPositive2 : {
+                            text : model.buttonPositive2.text,
                             onClick : model.buttonPositive.onClick
                         }
                     }

--- a/generics/components/templates/Template_SearchResult_Model.mjs
+++ b/generics/components/templates/Template_SearchResult_Model.mjs
@@ -72,7 +72,62 @@ export function Template_SearchResult_Model(model) {
                         text : model.button.text,
                         onClick : model.button.onClick
                     }
+                },
+                organism_searchResultDetail : {
+                    molecule_headerAndText : {
+                        atom_heading4 : {
+                            text : model.heading
+                        },
+                        atom_text1 : {
+                            text: model.infoText 
+                        }
+                    },
+                    atom_image : {
+                        src : model.src,
+                        alt : model.alt
+                    },
+                    molecule_list1 : {
+                        atom_heading4 : {
+                            text : model.listInfo
+                        },
+                        items: [
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                        ]
+                    },
+                    molecule_list2 : {
+                        atom_heading4 : {
+                            text : model.listProcess
+                        },
+                        items: [
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                        ]
+                    },
+                    molecule_list3 : {
+                        atom_heading4 : {
+                            text : model.listOrg
+                        },
+                        items: [
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                            {text: "List item"},
+                        ]
+                    },
+                    atom_buttonPositive : {
+                        text: model.buttonPositive.text,
+                        onClick : model.buttonPositive.onClick
+                    }
                 }
+
             }
         }
 

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,16 +29,23 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal-remove">
-                        <div class="modal-container-remove modal-search-res-det-remove">
-                            <div id="modal-id" class="modal-remove">
+
+                    
+                            <div id="modal-id">
                             </div>
-                        </div>
-                    </div>
+                        
+
                 </div>
             </div>
         </div>`
     }
+
+    // <div class="modal-remove">
+    //                     <div class="modal-container-remove modal-search-res-det-remove">
+    //                         <div id="modal-id" class="modal-remove">
+    //                         </div>
+    //                     </div>
+    //                 </div>
 
     this.bindScript = function() {
         let model = State.views[view].components;

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -4,6 +4,7 @@ import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Headin
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
+import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -12,15 +13,18 @@ export function Template_SearchResult_View(view){
     this.getHtml = function(){
         return `<div>
         ${slot("organismNavbar")}
+        ${slot("modal")}
         ${slot("organismSearchResultDetail")}
         </div>`
     }
 
     this.bindScript = function() {
         let model = State.views[view].components;
-        let organismNavbar = new Organism_Navbar(model.organism_navbar)
+        let modal = new Molecule_ModalSearchResultDetail(model.content)
+        let organismNavbar = new Organism_Navbar(model.content.organism_navbar)
         let organismSearchResultDetail = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
+        this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())
     }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -79,11 +79,11 @@ export function Template_SearchResult_View(view){
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
       
-            // const modalId = document.getElementById('modal-id')
+            const modalId = document.getElementById('modal-id')
       
-            // modalId.innerHTML = `
-            //     ${slot("new-modal")}
-            // `
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
             this.modal = new Modal_SearchResultDetail(model.content)
 
             this.fillSlot("new-modal", this.modal.getElement());

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,7 +3,6 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Atom_Input } from "nd_frontend/generics/components/atoms/Atom_Input.mjs"
-import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs";
 import { Atom_ButtonPositive } from "nd_frontend/generics/components/atoms/Atom_ButtonPositive.mjs"
 import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Molecule_Paginator.mjs"
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
@@ -29,7 +28,7 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div id="modal-id" class="modal-remove">
+                    <div id="modal-id">
                     </div>
                 </div>
             </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -25,7 +25,7 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(model.content.buttonPositive1)
+        let button = new Atom_ButtonPositive(model.atom_button)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -31,7 +31,8 @@ export function Template_SearchResult_View(view){
                     </div>
                     <div class="modal-remove">
                         <div class="modal-container-remove modal-search-res-det-remove">
-                            <div id="modal-id" class="modal-remove"></div>
+                            <div id="modal-id" class="modal-remove">
+                            ${slot("new-modal")}</div>
                         </div>
                     </div>
                 </div>
@@ -78,11 +79,11 @@ export function Template_SearchResult_View(view){
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
       
-            const modalId = document.getElementById('modal-id')
+            // const modalId = document.getElementById('modal-id')
       
-            modalId.innerHTML = `
-                ${slot("new-modal")}
-            `
+            // modalId.innerHTML = `
+            //     ${slot("new-modal")}
+            // `
             this.modal = new Modal_SearchResultDetail(model.content)
 
             this.fillSlot("new-modal", this.modal.getElement());

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -60,7 +60,6 @@ export function Template_SearchResult_View(view){
 
 
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
       
             const modalId = document.getElementById('modal-id')
       

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -40,16 +40,8 @@ export function Template_SearchResult_View(view){
         </div>`
     }
 
-    // ${slot("modal")}
-
     this.bindScript = function() {
         let model = State.views[view].components;
-        // let modal = new Molecule_ModalSearchResultDetail(model.content)
-        // this.fillSlot("modal", modal.getElement())
-       
-        // this.modal = new Modal(
-        //     this.content = new Molecule_ModalSearchResultDetail(model.content)
-        // )
 
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         this.fillSlot("organismNavbar", organismNavbar.getElement())
@@ -71,10 +63,6 @@ export function Template_SearchResult_View(view){
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
 
-        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-        //     document.querySelectorAll('.modal-container')[0].remove()
-        //     console.log('cross button pressed')
-        // });
 
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -9,6 +9,7 @@ import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Mo
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
 import { Modal } from "../organisms/Modal.mjs";
+import { Paragraph } from "../atoms/Paragraph.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -30,6 +31,7 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
+                    <div id="modal-id" class="modal"></div>
                 </div>
             </div>
         </div>`
@@ -40,16 +42,14 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         // let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let organismNavbar = new Organism_Navbar(model.organism_navbar)
-
-        this.modal = new Modal(
-            this.content = new Molecule_ModalSearchResultDetail(model.content)
-        )
-
         // this.fillSlot("modal", modal.getElement())
-        this.fillSlot("organismNavbar", organismNavbar.getElement())
+       
+        // this.modal = new Modal(
+        //     this.content = new Molecule_ModalSearchResultDetail(model.content)
+        // )
 
-        
+        let organismNavbar = new Organism_Navbar(model.organism_navbar)
+        this.fillSlot("organismNavbar", organismNavbar.getElement())
 
         let atom_input = new Atom_Input(model.atom_input)
         this.fillSlot("searchInput", atom_input.getElement())
@@ -67,5 +67,19 @@ export function Template_SearchResult_View(view){
         
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
+
+        this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
+      
+            const modalId = document.getElementById('modal-id')
+      
+            modalId.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal(
+              this.paragrap = new Paragraph("Testing")
+            )
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,11 +29,7 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal-remove">
-                        <div class="modal-container-remove modal-search-res-det-remove">
-                            <div id="modal-id" class="modal-remove">
-                            </div>
-                        </div>
+                    <div id="modal-id" class="modal-remove">
                     </div>
                 </div>
             </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -21,8 +21,8 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let organismNavbar = new Organism_Navbar(model.content.organism_navbar)
-        let organismSearchResultDetail = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+        let organismNavbar = new Organism_Navbar(model.organism_navbar)
+        let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -25,7 +25,7 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(model.buttonPositive1)
+        let button = new Atom_ButtonPositive(model.content.buttonPositive1)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -32,7 +32,7 @@ export function Template_SearchResult_View(view){
                     <div class="modal-remove">
                         <div class="modal-container-remove modal-search-res-det-remove">
                             <div id="modal-id" class="modal-remove">
-                            ${slot("new-modal")}</div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -82,7 +82,10 @@ export function Template_SearchResult_View(view){
             const modalId = document.getElementById('modal-id')
       
             modalId.innerHTML = `
+            <div>
                 ${slot("new-modal")}
+                <div id="modal-id-second"></div>
+            </div>
             `
             this.modal = new Modal_SearchResultDetail(model.content)
 

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -1,11 +1,8 @@
 import { Component } from "nd_frontend/core/Component.mjs";
 import { State } from "nd_frontend/core/actions/State.mjs";
-import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
-import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
-import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -18,16 +15,12 @@ export function Template_SearchResult_View(view){
         </div>`
     }
 
-    // ${slot("organismSearchResultDetail")}
-
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
-        // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
-        // this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,9 +29,9 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal">
-                        <div class="modal-container modal-search-res-det">
-                            <div id="modal-id" class="modal"></div>
+                    <div class="modal-remove">
+                        <div class="modal-container-remove modal-search-res-det-remove">
+                            <div id="modal-id" class="modal-remove"></div>
                         </div>
                     </div>
                 </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,7 +29,11 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div id="modal-id" class="modal"></div>
+                    <div class="modal">
+                        <div class="modal-container modal-search-res-det">
+                            <div id="modal-id" class="modal"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>`

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,6 +3,10 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+import { Modal } from "../organisms/Modal.mjs";
+import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
+
 
 export function Template_SearchResult_View(view){
     
@@ -12,6 +16,10 @@ export function Template_SearchResult_View(view){
         return `<div>
         ${slot("organismNavbar")}
         ${slot("modal")}
+        <div class=".org_searh_res_det_btn">
+        ${slot("button")}
+        </div>
+            ${slot("new-modal")}
         </div>`
     }
 
@@ -20,7 +28,20 @@ export function Template_SearchResult_View(view){
         let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
 
+        let text = new Atom_ButtonPositive(model.atom_buttonPositive)
+
         this.fillSlot("modal", modal.getElement())
+        this.fillSlot("text", text.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
+
+        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
+        console.log('btn from view pressed')
+        // document.querySelectorAll('.modal')[0].add()
+        
+        this.modal = new Modal(
+            this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
+        )
+        this.fillSlot("new-modal", this.modal.getElement());
+        });
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -70,6 +70,11 @@ export function Template_SearchResult_View(view){
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
 
+        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+        //     document.querySelectorAll('.modal-container')[0].remove()
+        //     console.log('cross button pressed')
+        // });
+
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
       

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -6,7 +6,6 @@ import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Modal } from "../organisms/Modal.mjs"
 
 export function Template_SearchResult_View(view){
     
@@ -17,7 +16,6 @@ export function Template_SearchResult_View(view){
         ${slot("organismNavbar")}
         ${slot("modal")}
         ${slot("button")}
-        ${slot("button1")}
         
         </div>`
     }
@@ -27,14 +25,12 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(new Molecule_ModalSearchResultDetail(model.content))
-        let button1 = new Atom_ButtonPositive(new Modal(model.content))
+        let button = new Atom_ButtonPositive(model.atom_button)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
 
         this.fillSlot("button", button.getElement())
-        this.fillSlot("button1", button1.getElement())
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         // this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,7 +3,6 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Atom_Input } from "nd_frontend/generics/components/atoms/Atom_Input.mjs"
-import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs";
 import { Atom_ButtonPositive } from "nd_frontend/generics/components/atoms/Atom_ButtonPositive.mjs"
 import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Molecule_Paginator.mjs"
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
@@ -29,23 +28,12 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-
-                    
-                            <div id="modal-id">
-                            </div>
-                        
-
+                    <div id="modal-id">
+                    </div>
                 </div>
             </div>
         </div>`
     }
-
-    // <div class="modal-remove">
-    //                     <div class="modal-container-remove modal-search-res-det-remove">
-    //                         <div id="modal-id" class="modal-remove">
-    //                         </div>
-    //                     </div>
-    //                 </div>
 
     this.bindScript = function() {
         let model = State.views[view].components;

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -15,8 +15,6 @@ export function Template_SearchResult_View(view){
         return `<div>
         ${slot("organismNavbar")}
         ${slot("modal")}
-        ${slot("button")}
-        
         </div>`
     }
 
@@ -25,12 +23,9 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(model.atom_button)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
-
-        this.fillSlot("button", button.getElement())
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         // this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -7,9 +7,6 @@ import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Headin
 import { Atom_ButtonPositive } from "nd_frontend/generics/components/atoms/Atom_ButtonPositive.mjs"
 import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Molecule_Paginator.mjs"
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
-import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
-import { Modal } from "../organisms/Modal.mjs";
-import { Paragraph } from "../atoms/Paragraph.mjs";
 import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
 
 export function Template_SearchResult_View(view){
@@ -32,9 +29,7 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal-container modal-search-res-det">
-                        <div id="modal-id" class="modal"></div>
-                    </div>
+                    <div id="modal-id" class="modal"></div>
                 </div>
             </div>
         </div>`
@@ -71,11 +66,6 @@ export function Template_SearchResult_View(view){
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
 
-        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-        //     document.querySelectorAll('.modal-container')[0].remove()
-        //     console.log('cross button pressed')
-        // });
-
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
       
@@ -84,9 +74,8 @@ export function Template_SearchResult_View(view){
             modalId.innerHTML = `
                 ${slot("new-modal")}
             `
-            this.modal = new Modal(
-              this.content = new Modal_SearchResultDetail(model.content)
-            )
+            this.modal = new Modal_SearchResultDetail(model.content)
+
             this.fillSlot("new-modal", this.modal.getElement());
         });
     }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,6 +3,7 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Atom_Input } from "nd_frontend/generics/components/atoms/Atom_Input.mjs"
+import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs";
 import { Atom_ButtonPositive } from "nd_frontend/generics/components/atoms/Atom_ButtonPositive.mjs"
 import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Molecule_Paginator.mjs"
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
@@ -28,7 +29,11 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div id="modal-id">
+                    <div class="modal-remove">
+                        <div class="modal-container-remove modal-search-res-det-remove">
+                            <div id="modal-id" class="modal-remove">
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,6 +3,7 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { Atom_Heading4 } from "nd_frontend/generics/components/atoms/Atom_Heading4.mjs"
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
+import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -11,16 +12,16 @@ export function Template_SearchResult_View(view){
     this.getHtml = function(){
         return `<div>
         ${slot("organismNavbar")}
-        ${slot("atomHeader")}
+        ${slot("organismSearchResultDetail")}
         </div>`
     }
 
     this.bindScript = function() {
         let model = State.views[view].components;
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
-        let atom_heading4 = new Atom_Heading4(model.atom_heading4)
+        let organismSearchResultDetail = new Organism_SearchResultDetail(model.organism_searchResultDetail)
 
         this.fillSlot("organismNavbar", organismNavbar.getElement())
-        this.fillSlot("atomHeader", atom_heading4.getElement())
+        this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -6,6 +6,7 @@ import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+import { Modal } from "../organisms/Modal.mjs"
 
 export function Template_SearchResult_View(view){
     
@@ -16,6 +17,7 @@ export function Template_SearchResult_View(view){
         ${slot("organismNavbar")}
         ${slot("modal")}
         ${slot("button")}
+        ${slot("button1")}
         
         </div>`
     }
@@ -25,12 +27,14 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(model.atom_button)
+        let button = new Atom_ButtonPositive(new Molecule_ModalSearchResultDetail(model.content))
+        let button1 = new Atom_ButtonPositive(new Modal(model.content))
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
 
         this.fillSlot("button", button.getElement())
+        this.fillSlot("button1", button1.getElement())
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         // this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -17,7 +17,7 @@ export function Template_SearchResult_View(view){
     this.getHtml = function(){
         return `<div>
         ${slot("organismNavbar")}
-        ${slot("modal")}
+       
         <div class="search-result-container">
                 <div class="search-result-content">
                     ${slot("searchInput")}
@@ -35,16 +35,18 @@ export function Template_SearchResult_View(view){
         </div>`
     }
 
+    // ${slot("modal")}
+
     this.bindScript = function() {
         let model = State.views[view].components;
-        let modal = new Molecule_ModalSearchResultDetail(model.content)
+        // let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
 
         this.modal = new Modal(
             this.content = new Molecule_ModalSearchResultDetail(model.content)
         )
 
-        this.fillSlot("modal", modal.getElement())
+        // this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
 
         

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -8,6 +8,7 @@ import { Atom_ButtonPositive } from "nd_frontend/generics/components/atoms/Atom_
 import { Molecule_Paginator } from "nd_frontend/generics/components/molecules/Molecule_Paginator.mjs"
 import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/molecules/Molecule_HeadingIconAndText.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
+import { Modal } from "../organisms/Modal.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -38,6 +39,10 @@ export function Template_SearchResult_View(view){
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
+
+        this.modal = new Modal(
+            this.content = new Molecule_ModalSearchResultDetail
+        )
 
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -28,10 +28,10 @@ export function Template_SearchResult_View(view){
         let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
 
-        let text = new Atom_ButtonPositive(model.atom_buttonPositive)
+        let button = new Atom_ButtonPositive(model.atom_buttonPositive)
 
         this.fillSlot("modal", modal.getElement())
-        this.fillSlot("text", text.getElement())
+        this.fillSlot("button", button.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
 
         this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -5,6 +5,7 @@ import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -14,18 +15,24 @@ export function Template_SearchResult_View(view){
         return `<div>
         ${slot("organismNavbar")}
         ${slot("modal")}
-        ${slot("organismSearchResultDetail")}
+        ${slot("button")}
+        
         </div>`
     }
+
+    // ${slot("organismSearchResultDetail")}
 
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
+        let button = new Atom_ButtonPositive(model.buttonPositive)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
-        let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
+        // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 
+
+        this.fillSlot("button", button.getElement())
         this.fillSlot("modal", modal.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
-        this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())
+        // this.fillSlot("organismSearchResultDetail", organismSearchResultDetail.getElement())
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -71,10 +71,10 @@ export function Template_SearchResult_View(view){
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
 
-        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelectorAll('.modal-container')[0].remove()
-            console.log('cross button pressed')
-        });
+        // this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+        //     document.querySelectorAll('.modal-container')[0].remove()
+        //     console.log('cross button pressed')
+        // });
 
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,9 +29,9 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal-remove">
-                        <div class="modal-container-remove modal-search-res-det-remove">
-                            <div id="modal-id" class="modal-remove">
+                    <div class="modal">
+                        <div class="modal-container modal-search-res-det">
+                            <div id="modal-id" class="modal">
                             </div>
                         </div>
                     </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -29,9 +29,9 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div class="modal">
-                        <div class="modal-container modal-search-res-det">
-                            <div id="modal-id" class="modal">
+                    <div class="modal-remove">
+                        <div class="modal-container-remove modal-search-res-det-remove">
+                            <div id="modal-id" class="modal-remove">
                             </div>
                         </div>
                     </div>

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -16,7 +16,7 @@ export function Template_SearchResult_View(view){
         return `<div>
         ${slot("organismNavbar")}
         ${slot("modal")}
-        <div class=".org_searh_res_det_btn">
+        <div class="org_searh_res_det_btn">
         ${slot("button")}
         </div>
             ${slot("new-modal")}

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -41,7 +41,7 @@ export function Template_SearchResult_View(view){
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
 
         this.modal = new Modal(
-            this.content = new Molecule_ModalSearchResultDetail
+            this.content = new Molecule_ModalSearchResultDetail(model.content)
         )
 
         this.fillSlot("modal", modal.getElement())

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -10,6 +10,7 @@ import { Molecule_HeadingIconAndText } from "nd_frontend/generics/components/mol
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
 import { Modal } from "../organisms/Modal.mjs";
 import { Paragraph } from "../atoms/Paragraph.mjs";
+import { Modal_SearchResultDetail } from "../organisms/Modal_SearchResultDetail.mjs";
 
 export function Template_SearchResult_View(view){
     
@@ -31,7 +32,9 @@ export function Template_SearchResult_View(view){
                     <div class="paginator-placement">
                     ${slot("paginator")}
                     </div>
-                    <div id="modal-id" class="modal"></div>
+                    <div class="modal-container modal-search-res-det">
+                        <div id="modal-id" class="modal"></div>
+                    </div>
                 </div>
             </div>
         </div>`
@@ -68,6 +71,11 @@ export function Template_SearchResult_View(view){
         let paginator = new Molecule_Paginator(model.molecule_paginator)
         this.fillSlot("paginator", paginator.getElement())
 
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelectorAll('.modal-container')[0].remove()
+            console.log('cross button pressed')
+        });
+
         this.getElement().querySelector(".overflow-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
       
@@ -77,7 +85,7 @@ export function Template_SearchResult_View(view){
                 ${slot("new-modal")}
             `
             this.modal = new Modal(
-              this.paragrap = new Paragraph("Testing")
+              this.content = new Modal_SearchResultDetail(model.content)
             )
             this.fillSlot("new-modal", this.modal.getElement());
         });

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -3,26 +3,15 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Molecule_ModalSearchResultDetail } from "../molecules/Molecule_ModalSearchResultDetail.mjs";
-import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Modal } from "../organisms/Modal.mjs";
-import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultDetail.mjs";
-
 
 export function Template_SearchResult_View(view){
     
-    this.content = content;
-    this.modal = null;
-
     Component.call(this)
 
     this.getHtml = function(){
         return `<div>
         ${slot("organismNavbar")}
         ${slot("modal")}
-        <div class="org_searh_res_det_btn">
-        ${slot("button")}
-        </div>
-            ${slot("new-modal")}
         </div>`
     }
 
@@ -31,20 +20,8 @@ export function Template_SearchResult_View(view){
         let modal = new Molecule_ModalSearchResultDetail(model.content)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
 
-        let button = new Atom_ButtonPositive(model.atom_buttonPositive)
-
         this.fillSlot("modal", modal.getElement())
-        this.fillSlot("button", button.getElement())
         this.fillSlot("organismNavbar", organismNavbar.getElement())
-
-        this.getElement().querySelector(".org_searh_res_det_btn").addEventListener("click", (e) => {
-        console.log('btn from view pressed')
-        // document.querySelectorAll('.modal')[0].add()
-        
-        this.modal = new Modal(
-            this.content = new Organism_SearchResultDetail(model.organism_searchResultDetail)
-        )
-        this.fillSlot("new-modal", this.modal.getElement());
-        });
+       
     }
 }

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -25,7 +25,7 @@ export function Template_SearchResult_View(view){
     this.bindScript = function() {
         let model = State.views[view].components;
         let modal = new Molecule_ModalSearchResultDetail(model.content)
-        let button = new Atom_ButtonPositive(model.buttonPositive)
+        let button = new Atom_ButtonPositive(model.buttonPositive1)
         let organismNavbar = new Organism_Navbar(model.organism_navbar)
         // let organismSearchResultDetail = new Organism_SearchResultDetail(model.content.organism_searchResultDetail)
 

--- a/generics/components/templates/Template_SearchResult_View.mjs
+++ b/generics/components/templates/Template_SearchResult_View.mjs
@@ -10,6 +10,9 @@ import { Organism_SearchResultDetail } from "../organisms/Organism_SearchResultD
 
 export function Template_SearchResult_View(view){
     
+    this.content = content;
+    this.modal = null;
+
     Component.call(this)
 
     this.getHtml = function(){

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -108,4 +108,5 @@
 
 .modal-org-add-to-proj {
   border-radius: 12px;
+  height: 628px;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -2,7 +2,14 @@
   height: 40px;
 }
 
-.modal-container, .model-container-second {
+.modal-container {
+  width: 497px;
+  box-shadow: 5px 15px 5px rgba(0, 0, 0, 0.04);
+  border: 1px solid #c6c7c8;
+  border-radius: 12px;
+}
+
+.model-container-second {
   width: 497px;
   box-shadow: 5px 15px 5px rgba(0, 0, 0, 0.04);
   border: 1px solid #c6c7c8;

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -92,6 +92,7 @@
 
 .modal-search-res-det {
   width: 520px;
+  background-color: white;
 }
 
 .modal-add-to-project {

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -6,7 +6,7 @@
   width: 497px;
   box-shadow: 5px 15px 5px rgba(0, 0, 0, 0.04);
   border: 1px solid #c6c7c8;
-  border-radius: 5px;
+  border-radius: 12px;
 }
 
 .upper-section {

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -98,3 +98,7 @@
 .modal-add-to-project {
   width: 328px;
 }
+
+.modal-org-add-to-proj {
+  border-radius: 12px;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -93,3 +93,7 @@
 .modal-search-res-det {
   width: 520px;
 }
+
+.modal-add-to-project {
+  width: 328px;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -83,10 +83,13 @@
   margin: 0 41px 0 72px;
 }
 
-.search-res-det-upper-section {
+.modal-search-res-det-upper-section {
   display: flex;
-  /* justify-content: space-between; */
   align-items: center;
   padding: 15px;
   justify-content: end
+}
+
+.modal-search-res-det {
+  width: 520px;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -82,3 +82,11 @@
   height: 161px;
   margin: 0 41px 0 72px;
 }
+
+.search-res-det-upper-section {
+  display: flex;
+  /* justify-content: space-between; */
+  align-items: center;
+  padding: 15px;
+  justify-content: end
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -2,7 +2,7 @@
   height: 40px;
 }
 
-.modal-container {
+.modal-container, .model-container-second {
   width: 497px;
   box-shadow: 5px 15px 5px rgba(0, 0, 0, 0.04);
   border: 1px solid #c6c7c8;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -201,6 +201,9 @@ nav > ul {
     width: 80%;
 }
 
+.overflow-container > div {
+    cursor: pointer;
+}
 
 .organism_add-to-proj {
     display: grid;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -76,11 +76,6 @@ nav > ul {
     grid-gap: 2rem;
 }
 
-.org_search_result_detail {
-    /* width: 575px; */
-    margin: auto;
-}
-
 .org_search_result_detail > div {
     margin-bottom: 3em;
 }
@@ -88,11 +83,6 @@ nav > ul {
 .org_search_res_det_top {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    /* width: 575px; */
-    /* width: 610px; */
-    /* gap: 34px; */
-    /* margin: auto;
-    margin-top: 3em; */
     margin: 3em 2em 1em 2em;
 }
 
@@ -102,24 +92,10 @@ nav > ul {
     justify-content: flex-end;
 }
 
-.org_search_res_det_top > .molecule_header-and-text{
-    /* margin-left: 3em; */
-}
-
 .org_search_res_det_top > div > .molecule_header-and-text > .atom_text1 {
     padding: 0;
     margin-top: 1em;
     margin-bottom: 0;
-
-}
-
-.org_search_res_det_top > div > .molecule_header-and-text {
-    /* margin-left: 3em; */
-}
-
-.org_search_res_det_top > .org_search_res_det_image {
-    display: flex;
-    justify-content: end;
 }
 
 .org_search_res_det_image > img{
@@ -131,8 +107,6 @@ nav > ul {
 .org_search_res_det_lists {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
-    /* width: 482px;
-    gap: 46px; */
     width: 470px;
     margin: auto;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -75,3 +75,14 @@ nav > ul {
     grid-auto-flow: row;
     grid-gap: 2rem;
 }
+
+.organism_search_res_det_image {
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    /*Preserve aspect ratio*/
+    min-width: 100%;
+    min-height: 100%;
+
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -94,8 +94,8 @@ nav > ul {
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {
-    justify-content: center;
-    align-items: flex-start;
-    gap: 2rem;
-    margin: 0;
+    justify-content: center !important;
+    align-items: flex-start !important;
+    gap: 2rem !important;
+    margin: 0 !important;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -92,3 +92,10 @@ nav > ul {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
 }
+
+.org_search_res_det_lists > ul {
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+    margin: 0;
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -111,6 +111,6 @@ nav > ul {
     grid-template-columns: 1fr;
 }
 
-.org_search_result_detail > button {
+.org_search_result_detail > .atom_button-positive {
     align-self: center;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -77,12 +77,12 @@ nav > ul {
 }
 
 .org_search_result_detail {
-    width: 575px;
+    /* width: 575px; */
     margin: auto;
 }
 
 .org_search_result_detail > div {
-    margin: 3em;
+    margin: 1em;
 }
 
 .org_search_res_det_top {
@@ -92,7 +92,7 @@ nav > ul {
     gap: 118px;
 }
 
-.org_search_res_det_top > div > .atom_text1 {
+.org_search_res_det_top > div > .molecule_header-and-text > .atom_text1 {
     padding: 0;
 }
 
@@ -104,8 +104,8 @@ nav > ul {
 .org_search_res_det_lists {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
-    width: 482px;
-    gap: 46px;
+    /* width: 482px;
+    gap: 46px; */
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -114,7 +114,7 @@ nav > ul {
 }
 
 .org_search_res_det_top > div > .molecule_header-and-text {
-    margin-left: 3em;
+    /* margin-left: 3em; */
 }
 
 .org_search_res_det_top > .org_search_res_det_image {
@@ -125,6 +125,7 @@ nav > ul {
 .org_search_res_det_image > img{
     height: 141px;
     width: 141px;
+    align-self: end;
 }
 
 .org_search_res_det_lists {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -116,6 +116,11 @@ nav > ul {
     margin-left: 3em;
 }
 
+.org_search_res_det_top > .org_search_res_det_image {
+    display: flex;
+    justify-content: end;
+}
+
 .org_search_res_det_image > img{
     height: 141px;
     width: 141px;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -196,3 +196,36 @@ nav > ul {
     height: 500px;
     width: 80%;
 }
+
+
+.organism_add-to-proj {
+    display: grid;
+}
+
+.organism_add-to-proj .molecule_text_and_dropdown {
+    margin: auto;
+    margin-top: 1em;
+}
+
+.mod-addToProj {
+    width: 328px !important;
+    margin: auto;
+}
+
+.organism_add-to-proj .molecule_text_and_dropdown > p {
+    padding: 0 !important;
+    text-align: center;
+}
+
+.org_add-to-proj-btn {
+    margin: 4em auto;
+}
+
+.org_add-to-proj-btn > button {
+    padding-left: 2em;
+    padding-right: 2em;
+}
+
+.mod-addToProj-cross {
+    justify-content: end !important;
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -82,7 +82,7 @@ nav > ul {
 }
 
 .org_search_result_detail > div {
-    margin: 1em;
+    margin: 3em;
 }
 
 .org_search_res_det_top {
@@ -111,6 +111,11 @@ nav > ul {
     grid-template-columns: 1fr;
 }
 
+.org_search_res_det_lists > .molecule_list > h4 {
+    margin-bottom: 2em;
+}
+
 .org_searh_res_det_btn {
-    align-self: center;
+    display: flex;
+    justify-content: center;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -92,6 +92,7 @@ nav > ul {
     width: 610px;
     gap: 34px;
     margin: auto;
+    margin-top: 3em;
 }
 
 .org_search_res_det_top > div {
@@ -106,6 +107,9 @@ nav > ul {
 
 .org_search_res_det_top > div > .molecule_header-and-text > .atom_text1 {
     padding: 0;
+    margin-top: 1em;
+    margin-bottom: 0;
+
 }
 
 .org_search_res_det_top > div > .molecule_header-and-text {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -76,7 +76,18 @@ nav > ul {
     grid-gap: 2rem;
 }
 
-.organism_search_res_det_image {
+.organism_search_res_det_image > img{
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    /*Preserve aspect ratio*/
+    min-width: 200px;
+    min-height: auto;
+
+}
+
+.organism_search_res_det_image > img{
     position: fixed;
     top: 0;
     left: 0;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -80,13 +80,11 @@ nav > ul {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
+
+}
+
+.organism_search_res_det_image > img{
     height: 141px;
     width: 141px;
 
 }
-
-/* .organism_search_res_det_image > img{
-    min-width: 100%;
-    min-height: 100%;
-
-} */

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -100,6 +100,8 @@ nav > ul {
 .org_search_res_det_lists {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
+    width: 482px;
+    gap: 46px;
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -130,7 +130,7 @@ nav > ul {
     margin: 3em 2em 1em 2em;
 }
 
-.org_search_res_det_top > .molecule_header-and-text {
+.org_search_res_det_top > div > .molecule_header-and-text {
     width: fit-content !important;
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -94,8 +94,10 @@ nav > ul {
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {
-    justify-content: center !important;
-    align-items: flex-start !important;
-    gap: 2rem !important;
-    margin: 0 !important;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -82,18 +82,34 @@ nav > ul {
 }
 
 .org_search_result_detail > div {
-    margin: 1em;
+    margin-bottom: 3em;
 }
 
 .org_search_res_det_top {
     display: grid;
     grid-template-columns: 1fr 1fr;
     /* width: 575px; */
-    gap: 118px;
+    width: 610px;
+    gap: 34px;
+    margin: auto;
+}
+
+.org_search_res_det_top > div {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.org_search_res_det_top > .molecule_header-and-text{
+    margin-left: 3em;
 }
 
 .org_search_res_det_top > div > .molecule_header-and-text > .atom_text1 {
     padding: 0;
+}
+
+.org_search_res_det_top > div > .molecule_header-and-text {
+    margin-left: 3em;
 }
 
 .org_search_res_det_image > img{
@@ -106,6 +122,9 @@ nav > ul {
     grid-template-columns: 1fr 1fr 1fr;
     /* width: 482px;
     gap: 46px; */
+    width: 417px;
+    margin: auto;
+    gap: 19px;
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {
@@ -118,7 +137,7 @@ nav > ul {
 }
 
 .org_search_res_det_lists > .molecule_list > h4 {
-    margin-bottom: 2em;
+    margin: 1.5em;
 }
 
 .org_searh_res_det_btn {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -76,15 +76,19 @@ nav > ul {
     grid-gap: 2rem;
 }
 
-.organism_search_res_det_image {
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center center;
-
+.org_search_res_det_top {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 575px;
+    gap: 118px;
 }
 
-.organism_search_res_det_image > img{
-    height: 141px;
-    width: 141px;
+.org_search_res_det_image > img{
+    height: 100%;
+    width: 100%;
+}
 
+.org_search_res_det_lists {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -77,23 +77,16 @@ nav > ul {
 }
 
 .organism_search_res_det_image {
-    position: fixed;
-    top: 0;
-    left: 0;
-
-    /*Preserve aspect ratio*/
-    min-width: 200px;
-    min-height: auto;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
+    height: 141px;
+    width: 141px;
 
 }
 
-.organism_search_res_det_image > img{
-    /* position: fixed;
-    top: 0;
-    left: 0; */
-
-    /*Preserve aspect ratio*/
+/* .organism_search_res_det_image > img{
     min-width: 100%;
     min-height: 100%;
 
-}
+} */

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -89,10 +89,11 @@ nav > ul {
     display: grid;
     grid-template-columns: 1fr 1fr;
     /* width: 575px; */
-    width: 610px;
-    gap: 34px;
-    margin: auto;
-    margin-top: 3em;
+    /* width: 610px; */
+    /* gap: 34px; */
+    /* margin: auto;
+    margin-top: 3em; */
+    margin: 3em 2em 1em 2em;
 }
 
 .org_search_res_det_top > div {
@@ -102,7 +103,7 @@ nav > ul {
 }
 
 .org_search_res_det_top > .molecule_header-and-text{
-    margin-left: 3em;
+    /* margin-left: 3em; */
 }
 
 .org_search_res_det_top > div > .molecule_header-and-text > .atom_text1 {
@@ -131,9 +132,8 @@ nav > ul {
     grid-template-columns: 1fr 1fr 1fr;
     /* width: 482px;
     gap: 46px; */
-    width: 417px;
+    width: 470px;
     margin: auto;
-    gap: 19px;
 }
 
 .org_search_res_det_lists > .molecule_list > .molecule_list__list {
@@ -152,5 +152,6 @@ nav > ul {
 .org_searh_res_det_btn {
     display: flex;
     justify-content: center;
+    margin-bottom: 2em;
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -94,8 +94,8 @@ nav > ul {
 }
 
 .org_search_res_det_lists > ul {
-    justify-content: center;
-    align-items: flex-start;
-    gap: 2rem;
-    margin: 0;
+    justify-content: center !important;
+    align-items: flex-start !important;
+    gap: 2rem !important;
+    margin: 0 !important;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -110,3 +110,7 @@ nav > ul {
     display: grid;
     grid-template-columns: 1fr;
 }
+
+.org_search_result_detail > button {
+    align-self: center;
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -93,9 +93,9 @@ nav > ul {
     grid-template-columns: 1fr 1fr 1fr;
 }
 
-.org_search_res_det_lists > ul {
-    justify-content: center !important;
-    align-items: flex-start !important;
-    gap: 2rem !important;
-    margin: 0 !important;
+.org_search_res_det_lists > .molecule_list > ul {
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+    margin: 0;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -130,6 +130,10 @@ nav > ul {
     margin: 3em 2em 1em 2em;
 }
 
+.org_search_res_det_top > .molecule_header-and-text {
+    width: fit-content !important;
+}
+
 .org_search_res_det_top > div {
     display: flex;
     flex-direction: column;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -82,7 +82,6 @@ nav > ul {
     justify-content: space-between;
     justify-items: center;
     align-items: center;
-    /* padding-left: 1rem; */
 }
 
 .organism_list-all-search__top > h2{
@@ -182,12 +181,9 @@ nav > ul {
 .search-result-container {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
-    /* grid-template-rows: repeat(6, 1fr); */
 }
 
 .search-result-content {
-    
-    /* grid-area: 2 / 2 / 5 / 7; */
     grid-area: 2 / 2 / 7 / 7;
     margin-top: 5em;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -76,7 +76,7 @@ nav > ul {
     grid-gap: 2rem;
 }
 
-.organism_search_res_det_image > img{
+.organism_search_res_det_image {
     position: fixed;
     top: 0;
     left: 0;
@@ -88,9 +88,9 @@ nav > ul {
 }
 
 .organism_search_res_det_image > img{
-    position: fixed;
+    /* position: fixed;
     top: 0;
-    left: 0;
+    left: 0; */
 
     /*Preserve aspect ratio*/
     min-width: 100%;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -76,6 +76,15 @@ nav > ul {
     grid-gap: 2rem;
 }
 
+.org_search_result_detail {
+    width: 575px;
+    margin: auto;
+}
+
+.org_search_result_detail > div {
+    margin: 1em;
+}
+
 .org_search_res_det_top {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -84,8 +93,8 @@ nav > ul {
 }
 
 .org_search_res_det_image > img{
-    height: 100%;
-    width: 100%;
+    height: 141px;
+    width: 141px;
 }
 
 .org_search_res_det_lists {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -88,8 +88,12 @@ nav > ul {
 .org_search_res_det_top {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    width: 575px;
+    /* width: 575px; */
     gap: 118px;
+}
+
+.org_search_res_det_top > div > .atom_text1 {
+    padding: 0;
 }
 
 .org_search_res_det_image > img{
@@ -121,3 +125,4 @@ nav > ul {
     display: flex;
     justify-content: center;
 }
+

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -182,11 +182,14 @@ nav > ul {
 .search-result-container {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
-    grid-template-rows: repeat(6, 1fr);
+    /* grid-template-rows: repeat(6, 1fr); */
 }
 
 .search-result-content {
-    grid-area: 2 / 2 / 5 / 7;
+    
+    /* grid-area: 2 / 2 / 5 / 7; */
+    grid-area: 2 / 2 / 7 / 7;
+    margin-top: 5em;
 }
 
 .search-result-content input {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -93,7 +93,7 @@ nav > ul {
     grid-template-columns: 1fr 1fr 1fr;
 }
 
-.org_search_res_det_lists > .molecule_list > ul {
+.org_search_res_det_lists > .molecule_list > .molecule_list__list {
     justify-content: center;
     align-items: flex-start;
     gap: 2rem;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -111,6 +111,6 @@ nav > ul {
     grid-template-columns: 1fr;
 }
 
-.org_search_result_detail > .atom_button-positive {
+.org_searh_res_det_btn {
     align-self: center;
 }


### PR DESCRIPTION
UC-100-add-modal-to-information-to-search-result-view


## Description & motivation

Creating modal for SearchResult based on "Molecule_ModalSearchResultDetail" which is a modified version of "ModalFrame" (due to unused content in the original version).
- Content is added to modal and styled according to mockup.
- This modal is visible at view --> needs to be modified to instead be shown as a pop-up modal from view.
- Cross at upper right modal removes modal when clicked on. 
- When clicked on "Add to project" new modal pops up based on "Modal" component --> This only works the first time! 

Navbar has not been modified in this ticket. 
No additional logic/functionality to this ticket.



## How to test

Add #UC-100-add-modal-to-information-to-search-result-view at the end of "nd_frontend" in package.json at UrbanCloud-alt1.
Run and start the project from Urban cloud.
Go to view /searchresult

## New tickets to be added

Functionalities and choice of modal to use. 



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
