### PR TITLE
Uc 98 add project info modal and create content to it to project view

### DIFF
--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -2,6 +2,7 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
+import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
 
 export function Molecule_ImageAndText ( model )
 {
@@ -14,6 +15,7 @@ export function Molecule_ImageAndText ( model )
             <div class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
+                <div id="modal-projectInfo"></div>
             </div>
         `;
     };
@@ -24,5 +26,18 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
+
+
+        this.getElement().querySelectorAll("molecule_image-and-text").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')      
+            const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -24,5 +24,10 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
+
+        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
+            // document.querySelectorAll('.modal')[0].remove()
+            console.log("card proj pressed")
+        });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -2,6 +2,7 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
+import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
 
 export function Molecule_ImageAndText ( model )
 {
@@ -14,6 +15,7 @@ export function Molecule_ImageAndText ( model )
             <div id="mol-img-text" class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
+                    <div id="modal-projectInfo"></div>
             </div>
         `;
     };
@@ -24,5 +26,20 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
+
+
+        const molTextImgage = document.getElementById("#mol-img-text")
+        molTextImgage.addEventListener("click", () => {
+
+            const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+
+        })
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -25,9 +25,9 @@ export function Molecule_ImageAndText ( model )
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
 
-        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
-            // document.querySelectorAll('.modal')[0].remove()
-            console.log("card proj pressed")
-        });
+        // this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
+        //     // document.querySelectorAll('.modal')[0].remove()
+        //     console.log("card proj pressed")
+        // });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -28,7 +28,7 @@ export function Molecule_ImageAndText ( model )
         this.fillSlot( "text1", text1.getElement() );
 
 
-        this.getElement().querySelectorAll("molecule_image-and-text").addEventListener("click", (e) => {
+        this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -14,7 +14,6 @@ export function Molecule_ImageAndText ( model )
             <div class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
-                <div id="modal-id" class="modal"></div>
             </div>
         `;
     };
@@ -25,10 +24,5 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
-
-        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
-            // document.querySelectorAll('.modal')[0].remove()
-            console.log("card proj pressed")
-        });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -14,6 +14,7 @@ export function Molecule_ImageAndText ( model )
             <div class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
+                <div id="modal-id" class="modal"></div>
             </div>
         `;
     };
@@ -25,9 +26,9 @@ export function Molecule_ImageAndText ( model )
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
 
-        // this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
-        //     // document.querySelectorAll('.modal')[0].remove()
-        //     console.log("card proj pressed")
-        // });
+        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", () => {
+            // document.querySelectorAll('.modal')[0].remove()
+            console.log("card proj pressed")
+        });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -2,7 +2,6 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
-import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
 
 export function Molecule_ImageAndText ( model )
 {
@@ -12,10 +11,9 @@ export function Molecule_ImageAndText ( model )
     {
 
         return `
-            <div class="molecule_image-and-text">
+            <div id="mol-img-text" class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
-                <div id="modal-projectInfo"></div>
             </div>
         `;
     };
@@ -26,18 +24,5 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
-
-
-        this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')      
-            const modalProjInfo = document.getElementById('modal-projectInfo')
-            
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
-
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
     };
 }

--- a/generics/components/molecules/Molecule_ImgAndText.mjs
+++ b/generics/components/molecules/Molecule_ImgAndText.mjs
@@ -2,7 +2,6 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
-import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
 
 export function Molecule_ImageAndText ( model )
 {
@@ -15,7 +14,6 @@ export function Molecule_ImageAndText ( model )
             <div id="mol-img-text" class="molecule_image-and-text">
                     ${ slot( "img" ) }
                     ${ slot( "text1" ) }
-                    <div id="modal-projectInfo"></div>
             </div>
         `;
     };
@@ -26,20 +24,5 @@ export function Molecule_ImageAndText ( model )
         let text1 = new Atom_Text1( model.atom_text1 );
         this.fillSlot( "img", img.getElement() );
         this.fillSlot( "text1", text1.getElement() );
-
-
-        const molTextImgage = document.getElementById("#mol-img-text")
-        molTextImgage.addEventListener("click", () => {
-
-            const modalProjInfo = document.getElementById('modal-projectInfo')
-            
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
-
-            this.fillSlot("new-modal", this.modal.getElement());
-
-        })
     };
 }

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -3,11 +3,13 @@ import {slot} from "../../../core/helpers.mjs";
 import { Atom_Heading4} from "../atoms/Atom_Heading4.mjs";
 
 export function Molecule_ListCheckBox(model = {}) {
+    
     const {type="text", placeholder="..."} = model
     this.props = {
         type,
         placeholder
     }
+
     Component.call(this)
 
     this.getHtml = function(){
@@ -26,13 +28,8 @@ export function Molecule_ListCheckBox(model = {}) {
         `
     }
 
-//     ${model.items1.map(item => `
-//     <p>${item.text}</p>
-// `).join('')}
-
     this.bindScript = function(){
         let heading = new Atom_Heading4(model.atom_heading4)
         this.fillSlot('heading', heading.getElement())
     }
-
 }

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -12,7 +12,7 @@ export function Molecule_ListCheckBox(model = {}) {
 
     this.getHtml = function(){
         return `
-                <div class="molecule_list">
+                <div class="molecule_list-wrapper">
                     ${slot('heading')}
                     <ul class="mol_checkbox-list-heading">
                         ${model.items.map(item => `

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -16,8 +16,10 @@ export function Molecule_ListCheckBox(model = {}) {
                     ${slot('heading')}
                     <ul class="molecule_list__list">
                         ${model.items.map(item => `
-                            <input class="atom_input" type="${item.type}" placeholder="${item.placeholder}">
-                            <h4>${item.text}</h4>
+                            <div>
+                                <input class="atom_input" type="${item.type}" placeholder="${item.placeholder}">
+                                <h4>${item.text}</h4>
+                            </div>
                         `).join('')}
                     </ul>
                 </div> 

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -18,7 +18,7 @@ export function Molecule_ListCheckBox(model = {}) {
                         ${model.items.map(item => `
                             <div class="molecule-input-text">
                                 <input class="atom_input" type="${item.type}" placeholder="${item.placeholder}">
-                                <h4>${item.text}</h4>
+                                <p>${item.text}</p>
                             </div>
                         `).join('')}
                     </ul>

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -14,9 +14,9 @@ export function Molecule_ListCheckBox(model = {}) {
         return `
                 <div class="molecule_list">
                     ${slot('heading')}
-                    <ul class="molecule_list__list">
+                    <ul class="mol_checkbox-list-heading">
                         ${model.items.map(item => `
-                            <div>
+                            <div class="molecule-input-text">
                                 <input class="atom_input" type="${item.type}" placeholder="${item.placeholder}">
                                 <h4>${item.text}</h4>
                             </div>

--- a/generics/components/molecules/Molecule_ListCheckBox.mjs
+++ b/generics/components/molecules/Molecule_ListCheckBox.mjs
@@ -1,0 +1,36 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Heading4} from "../atoms/Atom_Heading4.mjs";
+
+export function Molecule_ListCheckBox(model = {}) {
+    const {type="text", placeholder="..."} = model
+    this.props = {
+        type,
+        placeholder
+    }
+    Component.call(this)
+
+    this.getHtml = function(){
+        return `
+                <div class="molecule_list">
+                    ${slot('heading')}
+                    <ul class="molecule_list__list">
+                        ${model.items.map(item => `
+                            <input class="atom_input" type="${item.type}" placeholder="${item.placeholder}">
+                            <h4>${item.text}</h4>
+                        `).join('')}
+                    </ul>
+                </div> 
+        `
+    }
+
+//     ${model.items1.map(item => `
+//     <p>${item.text}</p>
+// `).join('')}
+
+    this.bindScript = function(){
+        let heading = new Atom_Heading4(model.atom_heading4)
+        this.fillSlot('heading', heading.getElement())
+    }
+
+}

--- a/generics/components/molecules/Molecule_ProjectState.mjs
+++ b/generics/components/molecules/Molecule_ProjectState.mjs
@@ -29,7 +29,7 @@ export function Molecule_ProjectState(model) {
         let box2 = new Atom_Text1(model.atom_text2)
         this.fillSlot("box2", box2.getElement());
 
-        let icon2 = new Atom_Dropdown(model.atom_icon2)
+        let icon2 = new Atom_Icon(model.atom_icon2)
         this.fillSlot("icon2", icon2.getElement());
 
         let box3 = new Atom_Text1(model.atom_text3)

--- a/generics/components/molecules/Molecule_ProjectState.mjs
+++ b/generics/components/molecules/Molecule_ProjectState.mjs
@@ -1,0 +1,39 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import {Atom_Text1} from "../atoms/Atom_Text1.mjs";
+import {Atom_Icon} from "../atoms/Atom_Icon.mjs";
+
+export function Molecule_ProjectState(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_text_and_dropdown">
+                ${slot("box1")}
+                ${slot("icon1")}
+                ${slot("box2")}
+                ${slot("icon2")}
+                ${slot("box3")}
+            </div>
+        `
+    }
+
+    this.bindScript= function() {
+        let box1 = new Atom_Text1(model.atom_text1)
+        this.fillSlot("box1", box1.getElement());
+
+        let icon1 = new Atom_Icon(model.atom_icon1)
+        this.fillSlot("icon1", icon1.getElement());
+
+        let box2 = new Atom_Text1(model.atom_text2)
+        this.fillSlot("box2", box2.getElement());
+
+        let icon2 = new Atom_Dropdown(model.atom_icon2)
+        this.fillSlot("icon2", icon2.getElement());
+
+        let box3 = new Atom_Text1(model.atom_text3)
+        this.fillSlot("box3", box3.getElement());
+    }
+
+}

--- a/generics/components/molecules/Molecule_ProjectState.mjs
+++ b/generics/components/molecules/Molecule_ProjectState.mjs
@@ -9,7 +9,7 @@ export function Molecule_ProjectState(model) {
     this.getHtml = function() {
 
         return `
-            <div class="molecule_text_and_dropdown">
+            <div class="molecule_project-state">
                 ${slot("box1")}
                 ${slot("icon1")}
                 ${slot("box2")}

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -25,8 +25,8 @@ export function Molecule_headingAboutImage(model) {
         let about = new Atom_Text1(model.atom_text1)
         this.fillSlot("about", about.getElement());
 
-        // let picture = new Atom_Image(model.atom_image)
-        // this.fillSlot("picture", picture.getElement());
+        let picture = new Atom_Image(model.atom_image)
+        this.fillSlot("picture", picture.getElement());
     }
 
 }

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -13,7 +13,9 @@ export function Molecule_headingAboutImage(model) {
             <div class="molecule_heading-abt-img">
                 ${slot("heading")}
                 ${slot("about")}
-                ${slot("picture")}
+                <div>
+                    ${slot("picture")}
+                </div>
             </div>
         `
     }

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -15,7 +15,7 @@ export function Molecule_headingAboutImage(model) {
                 ${slot("heading")}
                 ${slot("about")}
                 </div>
-                <div>
+                <div class="modal-projInfo-image">
                     ${slot("picture")}
                 </div>
             </div>

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -1,0 +1,32 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Heading4 } from "../atoms/Atom_Heading4.mjs";
+import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
+import { Atom_Image } from "../atoms/Atom_Image.mjs";
+
+export function Molecule_headingAboutImage(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_heading-abt-img">
+                ${slot("heading")}
+                ${slot("about")}
+                ${slot("picture")}
+            </div>
+        `
+    }
+
+    this.bindScript= function() {
+        let heading = new Atom_Heading4(model.atom_heading4)
+        this.fillSlot("heading", heading.getElement());
+
+        let about = new Atom_Text1(model.atom_text1)
+        this.fillSlot("about", about.getElement());
+
+        let picture = new Atom_Image(model.atom_image)
+        this.fillSlot("picture", picture.getElement());
+    }
+
+}

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -11,8 +11,10 @@ export function Molecule_headingAboutImage(model) {
 
         return `
             <div class="molecule_heading-abt-img">
+                <div class="mol_heading-abt">
                 ${slot("heading")}
                 ${slot("about")}
+                </div>
                 <div>
                     ${slot("picture")}
                 </div>

--- a/generics/components/molecules/Molecule_headingAboutImage.mjs
+++ b/generics/components/molecules/Molecule_headingAboutImage.mjs
@@ -25,8 +25,8 @@ export function Molecule_headingAboutImage(model) {
         let about = new Atom_Text1(model.atom_text1)
         this.fillSlot("about", about.getElement());
 
-        let picture = new Atom_Image(model.atom_image)
-        this.fillSlot("picture", picture.getElement());
+        // let picture = new Atom_Image(model.atom_image)
+        // this.fillSlot("picture", picture.getElement());
     }
 
 }

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -47,7 +47,7 @@ export function Modal_ProjectInfo(model) {
         })
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('#modal-background').remove()
+            document.querySelector('#modal-background')[0].remove()
             console.log('cross button pressed')
           });
     }

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -12,8 +12,8 @@ export function Modal_ProjectInfo(model) {
         return `
         <div id="modal-background" class="modal">
             <div class="modal-container modal-search-res-det">
-                <div class="modal-title-section">
-                    <div class="modal-search-res-det-upper-section">
+                <div class="modal-title-section modal-projInfo-section-bg">
+                    <div class="modal-projInfo-upper-section">
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -48,7 +48,6 @@ export function Modal_ProjectInfo(model) {
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
             document.querySelector('#modal-background').remove()
-            console.log('cross button pressed')
           });
     }
 

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -47,7 +47,7 @@ export function Modal_ProjectInfo(model) {
         })
 
         this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
-            document.querySelector('#modal-background')[0].remove()
+            document.querySelector('#modal-background').remove()
             console.log('cross button pressed')
           });
     }

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -5,13 +5,20 @@ import { Organism_ProjectInfo } from "./Organism_ProjectInfo.mjs";
 export function Modal_ProjectInfo(model) {
     Component.call(this)
 
-    this.content = content
-    this.content.modal = this;
+    this.content = model.content
+    this.modal = null;
 
     this.getHtml = function() {
         return `
-        <div class="modal">
+        <div id="modal-background" class="modal">
+            <div class="modal-container modal-search-res-det">
+                <div class="modal-title-section">
+                    <div class="modal-search-res-det-upper-section">
+                        <i class="bi bi-x"></i>
+                    </div>
+                </div> 
                 ${slot("content")}
+            </div>
         </div>
         `
     }

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -1,0 +1,46 @@
+import {slot} from "../../../core/helpers.mjs";
+import {Component} from "../../../core/Component.mjs";
+import { Organism_ProjectInfo } from "./Organism_ProjectInfo.mjs";
+
+export function Modal_ProjectInfo(content) {
+    Component.call(this)
+
+    this.content = content
+    this.content.modal = this;
+
+    this.getHtml = function() {
+        return `
+        <div class="modal">
+                ${slot("content")}
+        </div>
+        `
+    }
+
+    this.bindScript= function() {
+        this.content = new Organism_ProjectInfo(model.organism_projectInfo)
+        this.fillSlot("content", this.content.getElement());
+
+        const mStyle = this.getElement().style
+        mStyle.position = "absolute"
+        mStyle.width = window.innerWidth + "px"
+        mStyle.height = window.innerHeight + "px"
+        mStyle.top = "0px"
+        mStyle.left = "0px"
+        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        mStyle.display = "flex"
+        mStyle.justifyContent = "center"
+        mStyle.alignItems = "center"
+
+        this.content.getElement().style.backgroundColor = "white"
+
+        this.getElement().addEventListener("click", (e)=>{
+            if(e.target === this.getElement()){
+                this.getElement().remove()
+            }
+        })
+    }
+
+    this.show= function() {
+        document.body.append(this.getElement())
+    }
+}

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -10,7 +10,7 @@ export function Modal_ProjectInfo(model) {
 
     this.getHtml = function() {
         return `
-        <div id="modal-background" class="modal">
+        <div id="modal-background" class="modal modal-projectInfo">
             <div class="modal-container modal-search-res-det">
                 <div class="modal-title-section modal-projInfo-section-bg">
                     <div class="modal-projInfo-upper-section">

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -2,7 +2,7 @@ import {slot} from "../../../core/helpers.mjs";
 import {Component} from "../../../core/Component.mjs";
 import { Organism_ProjectInfo } from "./Organism_ProjectInfo.mjs";
 
-export function Modal_ProjectInfo(content) {
+export function Modal_ProjectInfo(model) {
     Component.call(this)
 
     this.content = content

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -10,8 +10,8 @@ export function Modal_ProjectInfo(model) {
 
     this.getHtml = function() {
         return `
-        <div id="modal-background" class="modal modal-projectInfo">
-            <div class="modal-container modal-search-res-det">
+        <div id="modal-background" class="modal">
+            <div class="modal-container modal-projectInfo">
                 <div class="modal-title-section modal-projInfo-section-bg">
                     <div class="modal-projInfo-upper-section">
                         <i class="bi bi-x"></i>

--- a/generics/components/organisms/Modal_ProjectInfo.mjs
+++ b/generics/components/organisms/Modal_ProjectInfo.mjs
@@ -45,6 +45,11 @@ export function Modal_ProjectInfo(model) {
                 this.getElement().remove()
             }
         })
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelector('#modal-background').remove()
+            console.log('cross button pressed')
+          });
     }
 
     this.show= function() {

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -14,7 +14,7 @@ export function Organism_ButtonFilledPictures ( model )
             <div id="organism_buttonFilledPicture_btnParent">
                 ${ slot( "btn" ) }
             </div>
-            <div id="org-cards-container">
+            <div id="org-cards-container" class="organism_buttonFilledPicture_wrapper">
                 ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
             </div>
         </div>

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -2,7 +2,6 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Molecule_ImageAndText } from "../molecules/Molecule_ImgAndText.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
-import { Modal_ProjectInfo } from "./Modal_ProjectInfo.mjs";
 
 export function Organism_ButtonFilledPictures ( model )
 {
@@ -15,10 +14,7 @@ export function Organism_ButtonFilledPictures ( model )
             <div id="organism_buttonFilledPicture_btnParent">
                 ${ slot( "btn" ) }
             </div>
-            <div class="organism_buttonfilledPic-cards">
             ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
-            </div>
-            <div id="modal-projectInfo">
         </div>
         `;
     };
@@ -33,18 +29,5 @@ export function Organism_ButtonFilledPictures ( model )
             let card = new Molecule_ImageAndText( cardData );
             this.fillSlot( "card" + index, card.getElement() );
         } );
-
-        this.getElement().querySelector("div.organism_buttonfilledPic-cards").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')      
-            const modalProjInfo = document.getElementById('modal-projectInfo')
-            
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
-
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
-
     };
 }

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -34,7 +34,7 @@ export function Organism_ButtonFilledPictures ( model )
             this.fillSlot( "card" + index, card.getElement() );
         } );
 
-        this.getElement().querySelector("organism_buttonfilledPic-cards").addEventListener("click", (e) => {
+        this.getElement().querySelector("div.organism_buttonfilledPic-cards").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -2,6 +2,7 @@ import { Component } from "../../../core/Component.mjs";
 import { slot } from "../../../core/helpers.mjs";
 import { Molecule_ImageAndText } from "../molecules/Molecule_ImgAndText.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+import { Modal_ProjectInfo } from "./Modal_ProjectInfo.mjs";
 
 export function Organism_ButtonFilledPictures ( model )
 {
@@ -14,7 +15,10 @@ export function Organism_ButtonFilledPictures ( model )
             <div id="organism_buttonFilledPicture_btnParent">
                 ${ slot( "btn" ) }
             </div>
+            <div class="organism_buttonfilledPic-cards">
             ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
+            </div>
+            <div id="modal-projectInfo">
         </div>
         `;
     };
@@ -29,5 +33,18 @@ export function Organism_ButtonFilledPictures ( model )
             let card = new Molecule_ImageAndText( cardData );
             this.fillSlot( "card" + index, card.getElement() );
         } );
+
+        this.getElement().querySelectorAll("organism_buttonfilledPic-cards").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')      
+            const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
+
     };
 }

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -34,7 +34,7 @@ export function Organism_ButtonFilledPictures ( model )
             this.fillSlot( "card" + index, card.getElement() );
         } );
 
-        this.getElement().querySelectorAll("organism_buttonfilledPic-cards").addEventListener("click", (e) => {
+        this.getElement().querySelector("organism_buttonfilledPic-cards").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -14,7 +14,9 @@ export function Organism_ButtonFilledPictures ( model )
             <div id="organism_buttonFilledPicture_btnParent">
                 ${ slot( "btn" ) }
             </div>
-            ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
+            <div id="org-cards-container">
+                ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
+            </div>
         </div>
         `;
     };

--- a/generics/components/organisms/Organism_ButtonFilledPictures.mjs
+++ b/generics/components/organisms/Organism_ButtonFilledPictures.mjs
@@ -14,7 +14,7 @@ export function Organism_ButtonFilledPictures ( model )
             <div id="organism_buttonFilledPicture_btnParent">
                 ${ slot( "btn" ) }
             </div>
-            <div id="org-cards-container" class="organism_buttonFilledPicture_wrapper">
+            <div id="org-cards-container" class="organism_buttonFilledcards">
                 ${ ( model.cards.map( ( card, index ) => slot( "card" + index ) ) ).join( "" ) }
             </div>
         </div>

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -27,8 +27,8 @@ export function Organism_ProjectInfo(model) {
     }
 
     this.bindScript= function() {
-        let molecule1 = new Molecule_headingAboutImage(model.molecule_headingAboutImage)
-        this.fillSlot("molecule1", molecule1.getElement());
+        // let molecule1 = new Molecule_headingAboutImage(model.molecule_headingAboutImage)
+        // this.fillSlot("molecule1", molecule1.getElement());
 
         let molecule2 = new Molecule_ProjectState(model.molecule_projectState)
         this.fillSlot("molecule2", molecule2.getElement());

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -1,0 +1,45 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs"
+import { Molecule_headingAboutImage } from "../molecules/Molecule_headingAboutImage.mjs";
+import { Molecule_ProjectState } from "../molecules/Molecule_ProjectState.mjs";
+import { Molecule_ListCheckBox } from "../molecules/Molecule_ListCheckBox.mjs";
+
+
+export function Organism_ProjectInfo(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="organism_project_info">
+                ${slot("molecule1")}
+                ${slot("molecule2")}
+                <div class="org-proj_info-checkboxes">
+                    ${slot("checkbox1")}
+                    ${slot("checkbox2")}
+                </div>
+                <div class="org_proj_info-btn">
+                ${slot("button")}
+                <div>
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+        let molecule1 = new Molecule_headingAboutImage(model.molecule_headingAboutImage)
+        this.fillSlot("molecule1", molecule1.getElement());
+
+        let molecule2 = new Molecule_ProjectState(model.molecule_projectState)
+        this.fillSlot("molecule2", molecule2.getElement());
+
+        let checkbox1 = new Molecule_ListCheckBox(model.molecule_listCheckbox1)
+        this.fillSlot("checkbox1", checkbox1.getElement());
+
+        let checkbox2 = new Molecule_ListCheckBox(model.molecule_listCheckbox2)
+        this.fillSlot("checkbox2", checkbox2.getElement());
+
+        let button = new Atom_ButtonPositive(model.atom_buttonPositive)
+        this.fillSlot("button", button.getElement());
+    }
+}

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -33,11 +33,11 @@ export function Organism_ProjectInfo(model) {
         let molecule2 = new Molecule_ProjectState(model.molecule_projectState)
         this.fillSlot("molecule2", molecule2.getElement());
 
-        let checkbox1 = new Molecule_ListCheckBox(model.molecule_listCheckbox1)
-        this.fillSlot("checkbox1", checkbox1.getElement());
+        // let checkbox1 = new Molecule_ListCheckBox(model.molecule_listCheckbox1)
+        // this.fillSlot("checkbox1", checkbox1.getElement());
 
-        let checkbox2 = new Molecule_ListCheckBox(model.molecule_listCheckbox2)
-        this.fillSlot("checkbox2", checkbox2.getElement());
+        // let checkbox2 = new Molecule_ListCheckBox(model.molecule_listCheckbox2)
+        // this.fillSlot("checkbox2", checkbox2.getElement());
 
         let button = new Atom_ButtonPositive(model.atom_buttonPositive)
         this.fillSlot("button", button.getElement());

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -15,7 +15,7 @@ export function Organism_ProjectInfo(model) {
             <div class="organism_project_info">
                 ${slot("molecule1")}
                 ${slot("molecule2")}
-                <div class="org-proj_info-checkboxes">
+                <div class="molecule-proj_info-checkboxes">
                     ${slot("checkbox1")}
                     ${slot("checkbox2")}
                 </div>

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -19,7 +19,7 @@ export function Organism_ProjectInfo(model) {
                     ${slot("checkbox1")}
                     ${slot("checkbox2")}
                 </div>
-                <div class="org_proj_info-btn">
+                <div class="modal-projectInfo-btn">
                 ${slot("button")}
                 <div>
             </div>

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -33,11 +33,11 @@ export function Organism_ProjectInfo(model) {
         let molecule2 = new Molecule_ProjectState(model.molecule_projectState)
         this.fillSlot("molecule2", molecule2.getElement());
 
-        // let checkbox1 = new Molecule_ListCheckBox(model.molecule_listCheckbox1)
-        // this.fillSlot("checkbox1", checkbox1.getElement());
+        let checkbox1 = new Molecule_ListCheckBox(model.molecule_listCheckbox1)
+        this.fillSlot("checkbox1", checkbox1.getElement());
 
-        // let checkbox2 = new Molecule_ListCheckBox(model.molecule_listCheckbox2)
-        // this.fillSlot("checkbox2", checkbox2.getElement());
+        let checkbox2 = new Molecule_ListCheckBox(model.molecule_listCheckbox2)
+        this.fillSlot("checkbox2", checkbox2.getElement());
 
         let button = new Atom_ButtonPositive(model.atom_buttonPositive)
         this.fillSlot("button", button.getElement());

--- a/generics/components/organisms/Organism_ProjectInfo.mjs
+++ b/generics/components/organisms/Organism_ProjectInfo.mjs
@@ -27,8 +27,8 @@ export function Organism_ProjectInfo(model) {
     }
 
     this.bindScript= function() {
-        // let molecule1 = new Molecule_headingAboutImage(model.molecule_headingAboutImage)
-        // this.fillSlot("molecule1", molecule1.getElement());
+        let molecule1 = new Molecule_headingAboutImage(model.molecule_headingAboutImage)
+        this.fillSlot("molecule1", molecule1.getElement());
 
         let molecule2 = new Molecule_ProjectState(model.molecule_projectState)
         this.fillSlot("molecule2", molecule2.getElement());

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -294,7 +294,6 @@ export function Template_Projects_Model ( model )
           }
         }
       }
-      
     }
   };
 

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -256,8 +256,8 @@ export function Template_Projects_Model ( model )
             text : model.projModalAbout
           },
           atom_image : {
-            src: "",
-            alt: "project picture"
+            src: model.projImageSrc,
+            alt: model.projImageAlt
           }
         },
         molecule_projectState : {

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -79,223 +79,222 @@ export function Template_Projects_Model ( model )
         }
     },
       Organism_ButtonFilledPictures: {
-        btn: {
-          text: model.btnText,
-          onClick: model.onClick,
-        },
-        cards: [
-          {
-            atom_img: {
-              imgSrc: model.cards[ 0 ].imgSrc,
-              imgAlt: model.cards[ 0 ].imgAlt,
-              text: model.cards[ 0 ].text,
-            },
-            atom_text1: {
-              text: model.cards[ 0 ].text,
-            }
+      btn: {
+        text: model.btnText,
+        onClick: model.onClick,
+      },
+      cards: [
+        {
+          atom_img: {
+            imgSrc: model.cards[ 0 ].imgSrc,
+            imgAlt: model.cards[ 0 ].imgAlt,
+            text: model.cards[ 0 ].text,
           },
-          {
-            atom_img: {
-              imgSrc: model.cards[ 1 ].imgSrc,
-              imgAlt: model.cards[ 1 ].imgAlt,
-              text: model.cards[ 1 ].text,
-            },
-            atom_text1: {
-              text: model.cards[ 1 ].text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            atom_img: {
-              imgSrc: model.imgSrc,
-              imgAlt: model.imgAlt,
-              text: model.text,
-            },
-            atom_text1: {
-              text: model.text,
-            }
-          },
-          {
-            content : {
-              organism_projectInfo : {
-                molecule_headingAboutImage : {
-                  atom_heading4 : {
-                    text : model.projModalHeading
-                  },
-                  atom_text1 : {
-                    text : model.projModalAbout
-                  },
-                  atom_image : {
-                    src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
-                    alt: "project picture"
-                  }
-                },
-                molecule_projectState : {
-                  atom_text1 : {
-                    text : model.previousBox
-                  },
-                  atom_icon1 : {
-                    icon : model.icon6
-                  }, atom_text2 : {
-                    text : model.currentBox
-                  },
-                  atom_icon2 : {
-                    icon : model.icon7
-                  },
-                  atom_text3 : {
-                    text : model.nextBox
-                  }
-                },
-                molecule_listCheckbox1 :{
-                  atom_heading4 : {
-                    text : model.subHeading1
-                  },
-                  items: model.items1
-                },
-                molecule_listCheckbox2 :{
-                  atom_heading4 : {
-                    text : model.subHeading2
-                  },
-                  items : model.items2
-                },
-                atom_buttonPositive : {
-                  text : model.buttonPositive.text,
-                  onClick : model.buttonPositive.onClick
-                }
-              }
-            }
+          atom_text1: {
+            text: model.cards[ 0 ].text,
           }
-        ]
-      }
+        },
+        {
+          atom_img: {
+            imgSrc: model.cards[ 1 ].imgSrc,
+            imgAlt: model.cards[ 1 ].imgAlt,
+            text: model.cards[ 1 ].text,
+          },
+          atom_text1: {
+            text: model.cards[ 1 ].text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        },
+        {
+          atom_img: {
+            imgSrc: model.imgSrc,
+            imgAlt: model.imgAlt,
+            text: model.text,
+          },
+          atom_text1: {
+            text: model.text,
+          }
+        }
+      ]
+    },
+      content : {
+        organism_projectInfo : {
+          molecule_headingAboutImage : {
+            atom_heading4 : {
+              text : model.projModalHeading
+            },
+            atom_text1 : {
+              text : model.projModalAbout
+            },
+            atom_image : {
+              src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+              alt: "project picture"
+            }
+          },
+          molecule_projectState : {
+            atom_text1 : {
+              text : model.previousBox
+            },
+            atom_icon1 : {
+              icon : model.icon6
+            }, atom_text2 : {
+              text : model.currentBox
+            },
+            atom_icon2 : {
+              icon : model.icon7
+            },
+            atom_text3 : {
+              text : model.nextBox
+            }
+          },
+          molecule_listCheckbox1 :{
+            atom_heading4 : {
+              text : model.subHeading1
+            },
+            items: model.items1
+          },
+          molecule_listCheckbox2 :{
+            atom_heading4 : {
+              text : model.subHeading2
+            },
+            items : model.items2
+          },
+          atom_buttonPositive : {
+            text : model.buttonPositive.text,
+            onClick : model.buttonPositive.onClick
+          }
+        }
+    }
+
     }
   };
 

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -244,55 +244,57 @@ export function Template_Projects_Model ( model )
               text: model.text,
             }
           },
-        ],
-        content : {
-          organism_projectInfo : {
-            molecule_headingAboutImage : {
-              atom_heading4 : {
-                text : model.projModalHeading
-              },
-              atom_text1 : {
-                text : model.projModalAbout
-              },
-              atom_image : {
-                src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
-                alt: "project picture"
+          {
+            content : {
+              organism_projectInfo : {
+                molecule_headingAboutImage : {
+                  atom_heading4 : {
+                    text : model.projModalHeading
+                  },
+                  atom_text1 : {
+                    text : model.projModalAbout
+                  },
+                  atom_image : {
+                    src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+                    alt: "project picture"
+                  }
+                },
+                molecule_projectState : {
+                  atom_text1 : {
+                    text : model.previousBox
+                  },
+                  atom_icon1 : {
+                    icon : model.icon6
+                  }, atom_text2 : {
+                    text : model.currentBox
+                  },
+                  atom_icon2 : {
+                    icon : model.icon7
+                  },
+                  atom_text3 : {
+                    text : model.nextBox
+                  }
+                },
+                molecule_listCheckbox1 :{
+                  atom_heading4 : {
+                    text : model.subHeading1
+                  },
+                  items: model.items1
+                },
+                molecule_listCheckbox2 :{
+                  atom_heading4 : {
+                    text : model.subHeading2
+                  },
+                  items : model.items2
+                },
+                atom_buttonPositive : {
+                  text : model.buttonPositive.text,
+                  onClick : model.buttonPositive.onClick
+                }
               }
-            },
-            molecule_projectState : {
-              atom_text1 : {
-                text : model.previousBox
-              },
-              atom_icon1 : {
-                icon : model.icon6
-              }, atom_text2 : {
-                text : model.currentBox
-              },
-              atom_icon2 : {
-                icon : model.icon7
-              },
-              atom_text3 : {
-                text : model.nextBox
-              }
-            },
-            molecule_listCheckbox1 :{
-              atom_heading4 : {
-                text : model.subHeading1
-              },
-              items: model.items1
-            },
-            molecule_listCheckbox2 :{
-              atom_heading4 : {
-                text : model.subHeading2
-              },
-              items : model.items2
-            },
-            atom_buttonPositive : {
-              text : model.buttonPositive.text,
-              onClick : model.buttonPositive.onClick
             }
           }
-        }
+        ]
       }
     }
   };

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -246,7 +246,6 @@ export function Template_Projects_Model ( model )
           },
         ]
       },
-      content : {
         organism_projectInfo :{
           molecule_headingAboutImage : {
             atom_heading4 : {
@@ -293,7 +292,7 @@ export function Template_Projects_Model ( model )
             onClick : model.buttonPositive.onClick
           }
         }
-      }
+      
       
     }
   };

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -256,7 +256,7 @@ export function Template_Projects_Model ( model )
               text : model.projModalAbout
             },
             atom_image : {
-              src: "",
+              src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
               alt: "project picture"
             }
           },

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -244,53 +244,53 @@ export function Template_Projects_Model ( model )
               text: model.text,
             }
           },
-        ]
-      },
-      content : {
-        organism_projectInfo : {
-          molecule_headingAboutImage : {
-            atom_heading4 : {
-              text : model.projModalHeading
+        ],
+        content : {
+          organism_projectInfo : {
+            molecule_headingAboutImage : {
+              atom_heading4 : {
+                text : model.projModalHeading
+              },
+              atom_text1 : {
+                text : model.projModalAbout
+              },
+              atom_image : {
+                src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+                alt: "project picture"
+              }
             },
-            atom_text1 : {
-              text : model.projModalAbout
+            molecule_projectState : {
+              atom_text1 : {
+                text : model.previousBox
+              },
+              atom_icon1 : {
+                icon : model.icon6
+              }, atom_text2 : {
+                text : model.currentBox
+              },
+              atom_icon2 : {
+                icon : model.icon7
+              },
+              atom_text3 : {
+                text : model.nextBox
+              }
             },
-            atom_image : {
-              src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
-              alt: "project picture"
+            molecule_listCheckbox1 :{
+              atom_heading4 : {
+                text : model.subHeading1
+              },
+              items: model.items1
+            },
+            molecule_listCheckbox2 :{
+              atom_heading4 : {
+                text : model.subHeading2
+              },
+              items : model.items2
+            },
+            atom_buttonPositive : {
+              text : model.buttonPositive.text,
+              onClick : model.buttonPositive.onClick
             }
-          },
-          molecule_projectState : {
-            atom_text1 : {
-              text : model.previousBox
-            },
-            atom_icon1 : {
-              icon : model.icon6
-            }, atom_text2 : {
-              text : model.currentBox
-            },
-            atom_icon2 : {
-              icon : model.icon7
-            },
-            atom_text3 : {
-              text : model.nextBox
-            }
-          },
-          molecule_listCheckbox1 :{
-            atom_heading4 : {
-              text : model.subHeading1
-            },
-            items: model.items1
-          },
-          molecule_listCheckbox2 :{
-            atom_heading4 : {
-              text : model.subHeading2
-            },
-            items : model.items2
-          },
-          atom_buttonPositive : {
-            text : model.buttonPositive.text,
-            onClick : model.buttonPositive.onClick
           }
         }
       }

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -247,7 +247,7 @@ export function Template_Projects_Model ( model )
         ]
       },
       content : {
-        organism_projectInfo :{
+        organism_projectInfo : {
           molecule_headingAboutImage : {
             atom_heading4 : {
               text : model.projModalHeading

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -256,7 +256,7 @@ export function Template_Projects_Model ( model )
             text : model.projModalAbout
           },
           atom_image : {
-            src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+            src: "",
             alt: "project picture"
           }
         },

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -243,58 +243,61 @@ export function Template_Projects_Model ( model )
           atom_text1: {
             text: model.text,
           }
+        },
+        {
+          content : {
+            organism_projectInfo : {
+              molecule_headingAboutImage : {
+                atom_heading4 : {
+                  text : model.projModalHeading
+                },
+                atom_text1 : {
+                  text : model.projModalAbout
+                },
+                atom_image : {
+                  src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+                  alt: "project picture"
+                }
+              },
+              molecule_projectState : {
+                atom_text1 : {
+                  text : model.previousBox
+                },
+                atom_icon1 : {
+                  icon : model.icon6
+                }, atom_text2 : {
+                  text : model.currentBox
+                },
+                atom_icon2 : {
+                  icon : model.icon7
+                },
+                atom_text3 : {
+                  text : model.nextBox
+                }
+              },
+              molecule_listCheckbox1 :{
+                atom_heading4 : {
+                  text : model.subHeading1
+                },
+                items: model.items1
+              },
+              molecule_listCheckbox2 :{
+                atom_heading4 : {
+                  text : model.subHeading2
+                },
+                items : model.items2
+              },
+              atom_buttonPositive : {
+                text : model.buttonPositive.text,
+                onClick : model.buttonPositive.onClick
+              }
+            }
         }
+        }
+        
       ]
     },
-      content : {
-        organism_projectInfo : {
-          molecule_headingAboutImage : {
-            atom_heading4 : {
-              text : model.projModalHeading
-            },
-            atom_text1 : {
-              text : model.projModalAbout
-            },
-            atom_image : {
-              src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
-              alt: "project picture"
-            }
-          },
-          molecule_projectState : {
-            atom_text1 : {
-              text : model.previousBox
-            },
-            atom_icon1 : {
-              icon : model.icon6
-            }, atom_text2 : {
-              text : model.currentBox
-            },
-            atom_icon2 : {
-              icon : model.icon7
-            },
-            atom_text3 : {
-              text : model.nextBox
-            }
-          },
-          molecule_listCheckbox1 :{
-            atom_heading4 : {
-              text : model.subHeading1
-            },
-            items: model.items1
-          },
-          molecule_listCheckbox2 :{
-            atom_heading4 : {
-              text : model.subHeading2
-            },
-            items : model.items2
-          },
-          atom_buttonPositive : {
-            text : model.buttonPositive.text,
-            onClick : model.buttonPositive.onClick
-          }
-        }
-    }
-
+    
     }
   };
 

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -246,6 +246,7 @@ export function Template_Projects_Model ( model )
           },
         ]
       },
+      content : {
         organism_projectInfo :{
           molecule_headingAboutImage : {
             atom_heading4 : {
@@ -292,7 +293,7 @@ export function Template_Projects_Model ( model )
             onClick : model.buttonPositive.onClick
           }
         }
-      
+      }
       
     }
   };

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -243,60 +243,57 @@ export function Template_Projects_Model ( model )
           atom_text1: {
             text: model.text,
           }
-        },
-        {
-          content : {
-            organism_projectInfo : {
-              molecule_headingAboutImage : {
-                atom_heading4 : {
-                  text : model.projModalHeading
-                },
-                atom_text1 : {
-                  text : model.projModalAbout
-                },
-                atom_image : {
-                  src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
-                  alt: "project picture"
-                }
-              },
-              molecule_projectState : {
-                atom_text1 : {
-                  text : model.previousBox
-                },
-                atom_icon1 : {
-                  icon : model.icon6
-                }, atom_text2 : {
-                  text : model.currentBox
-                },
-                atom_icon2 : {
-                  icon : model.icon7
-                },
-                atom_text3 : {
-                  text : model.nextBox
-                }
-              },
-              molecule_listCheckbox1 :{
-                atom_heading4 : {
-                  text : model.subHeading1
-                },
-                items: model.items1
-              },
-              molecule_listCheckbox2 :{
-                atom_heading4 : {
-                  text : model.subHeading2
-                },
-                items : model.items2
-              },
-              atom_buttonPositive : {
-                text : model.buttonPositive.text,
-                onClick : model.buttonPositive.onClick
-              }
-            }
         }
-        }
-        
       ]
     },
+      content : {
+      organism_projectInfo : {
+        molecule_headingAboutImage : {
+          atom_heading4 : {
+            text : model.projModalHeading
+          },
+          atom_text1 : {
+            text : model.projModalAbout
+          },
+          atom_image : {
+            src: "https://images.pexels.com/photos/3609139/pexels-photo-3609139.jpeg",
+            alt: "project picture"
+          }
+        },
+        molecule_projectState : {
+          atom_text1 : {
+            text : model.previousBox
+          },
+          atom_icon1 : {
+            icon : model.icon6
+          }, atom_text2 : {
+            text : model.currentBox
+          },
+          atom_icon2 : {
+            icon : model.icon7
+          },
+          atom_text3 : {
+            text : model.nextBox
+          }
+        },
+        molecule_listCheckbox1 :{
+          atom_heading4 : {
+            text : model.subHeading1
+          },
+          items: model.items1
+        },
+        molecule_listCheckbox2 :{
+          atom_heading4 : {
+            text : model.subHeading2
+          },
+          items : model.items2
+        },
+        atom_buttonPositive : {
+          text : model.buttonPositive.text,
+          onClick : model.buttonPositive.onClick
+        }
+      }
+    }
     
     }
   };

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -245,7 +245,56 @@ export function Template_Projects_Model ( model )
             }
           },
         ]
+      },
+      content : {
+        organism_projectInfo :{
+          molecule_headingAboutImage : {
+            atom_heading4 : {
+              text : model.projModalHeading
+            },
+            atom_text1 : {
+              text : model.projModalAbout
+            },
+            atom_image : {
+              src: "",
+              alt: "project picture"
+            }
+          },
+          molecule_projectState : {
+            atom_text1 : {
+              text : model.previousBox
+            },
+            atom_icon1 : {
+              icon : model.icon6
+            }, atom_text2 : {
+              text : model.currentBox
+            },
+            atom_icon2 : {
+              icon : model.icon7
+            },
+            atom_text3 : {
+              text : model.nextBox
+            }
+          },
+          molecule_listCheckbox1 :{
+            atom_heading4 : {
+              text : model.subHeading1
+            },
+            items: model.items1
+          },
+          molecule_listCheckbox2 :{
+            atom_heading4 : {
+              text : model.subHeading2
+            },
+            items : model.items2
+          },
+          atom_buttonPositive : {
+            text : model.buttonPositive.text,
+            onClick : model.buttonPositive.onClick
+          }
+        }
       }
+      
     }
   };
 

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -3,6 +3,7 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_ButtonFilledPictures } from "../organisms/Organism_ButtonFilledPictures.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
+import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
 
 export function Template_Projects_View ( view )
 {
@@ -15,6 +16,7 @@ export function Template_Projects_View ( view )
         <div class="grid-template-projects">
         ${slot("organismNavbar")}
             ${ slot( "organismButtonFilledPictures" ) }
+            ${slot("projInfoModal")}
         </div>`;
     };
 
@@ -28,5 +30,9 @@ export function Template_Projects_View ( view )
         let organismButtonFilledPictures = new Organism_ButtonFilledPictures( model.Organism_ButtonFilledPictures );
 
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
+
+        let projInfoModal = new Modal_ProjectInfo(model.content)
+        this.fillSlot("projInfoModal", projInfoModal.getElement())
+
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -45,8 +45,23 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelector("div.molecule_image-and-text").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')      
+        // this.getElement().querySelector("").addEventListener("click", (e) => {
+        //     console.log('btn-project button pressed')
+            
+    
+        //     const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+        //     modalProjInfo.innerHTML = `
+        //         ${slot("new-modal")}
+        //     `
+        //     this.modal = new Modal_ProjectInfo(model.content)
+
+        //     this.fillSlot("new-modal", this.modal.getElement());
+        // });
+
+        const molTextImgage = document.getElementById("#mol-img-text")
+        molTextImgage.addEventListener("click", () => {
+
             const modalProjInfo = document.getElementById('modal-projectInfo')
             
             modalProjInfo.innerHTML = `
@@ -55,8 +70,7 @@ export function Template_Projects_View ( view )
             this.modal = new Modal_ProjectInfo(model.content)
 
             this.fillSlot("new-modal", this.modal.getElement());
-        });
 
-
+        })
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -32,7 +32,6 @@ export function Template_Projects_View ( view )
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
         this.getElement().querySelector("#org-cards-container").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
             
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -48,14 +48,14 @@ export function Template_Projects_View ( view )
             console.log('btn-project button pressed')
             
     
-            // const modalProjInfo = document.getElementById('modal-projectInfo')
+            const modalProjInfo = document.getElementById('modal-projectInfo')
             
-            // modalProjInfo.innerHTML = `
-            //     ${slot("new-modal")}
-            // `
-            // this.modal = new Modal_ProjectInfo(model.content)
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
 
-            // this.fillSlot("new-modal", this.modal.getElement());
+            this.fillSlot("new-modal", this.modal.getElement());
         });
 
         // const molTextImgage = document.getElementById("#mol-img-text")

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -16,9 +16,7 @@ export function Template_Projects_View ( view )
         return `
         <div class="grid-template-projects">
             ${slot("organismNavbar")}
-            <div class="organism_btn-filled-pictures">
-                ${slot( "organismButtonFilledPictures")}
-            </div>
+            ${slot( "organismButtonFilledPictures")}
             <div id="modal-projectInfo">
         </div>`;
     };

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -18,6 +18,7 @@ export function Template_Projects_View ( view )
             ${slot("organismNavbar")}
             <div class="organism_btn-filled-pictures">
                 ${slot( "organismButtonFilledPictures")}
+                <div id="modal-projectInfo"></div>
             </div>
             
         </div>`;
@@ -25,7 +26,7 @@ export function Template_Projects_View ( view )
 
     // ${slot("projInfoModal")}
 
-    // <div id="modal-projectInfo"></div>
+    
 
     this.bindScript = function ()
     {
@@ -44,17 +45,17 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        // this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
-        //     console.log('btn-project button pressed')      
-        //     const modalProjInfo = document.getElementById('modal-projectInfo')
+        this.getElement().querySelector("div.molecule_image-and-text").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')      
+            const modalProjInfo = document.getElementById('modal-projectInfo')
             
-        //     modalProjInfo.innerHTML = `
-        //         ${slot("new-modal")}
-        //     `
-        //     this.modal = new Modal_ProjectInfo(model.content)
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
 
-        //     this.fillSlot("new-modal", this.modal.getElement());
-        // });
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
 
 
     };

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -8,7 +8,6 @@ import { Organism_ProjectInfo } from "../organisms/Organism_ProjectInfo.mjs";
 
 export function Template_Projects_View ( view )
 {
-
     Component.call( this );
 
     this.getHtml = function ()
@@ -21,10 +20,6 @@ export function Template_Projects_View ( view )
         </div>`;
     };
 
-    // ${slot("projInfoModal")}
-
-    
-
     this.bindScript = function ()
     {
         let model = State.views[ view ].components;
@@ -36,16 +31,9 @@ export function Template_Projects_View ( view )
 
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
-        // let projInfoModal = new Modal_ProjectInfo(model.content)
-        // this.fillSlot("projInfoModal", projInfoModal.getElement())
-
-        // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
-        // this.fillSlot("projInfoModal", projInfoModal.getElement())
-
         this.getElement().querySelector("#org-cards-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
             
-    
             const modalProjInfo = document.getElementById('modal-projectInfo')
             
             modalProjInfo.innerHTML = `
@@ -55,19 +43,5 @@ export function Template_Projects_View ( view )
 
             this.fillSlot("new-modal", this.modal.getElement());
         });
-
-        // const molTextImgage = document.getElementById("#mol-img-text")
-        // molTextImgage.addEventListener("click", () => {
-
-        //     const modalProjInfo = document.getElementById('modal-projectInfo')
-            
-        //     modalProjInfo.innerHTML = `
-        //         ${slot("new-modal")}
-        //     `
-        //     this.modal = new Modal_ProjectInfo(model.content)
-
-        //     this.fillSlot("new-modal", this.modal.getElement());
-
-        // })
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -42,7 +42,7 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelector(".organism_btn-filled-pictures").addEventListener("click", (e) => {
+        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -18,7 +18,7 @@ export function Template_Projects_View ( view )
             ${slot("organismNavbar")}
             <div class="organism_btn-filled-pictures">
                 ${slot( "organismButtonFilledPictures")}
-                <div id="modal-projectInfo"></div>
+                
             </div>
             
         </div>`;
@@ -59,18 +59,6 @@ export function Template_Projects_View ( view )
         //     this.fillSlot("new-modal", this.modal.getElement());
         // });
 
-        const molTextImgage = document.getElementById("#mol-img-text")
-        molTextImgage.addEventListener("click", () => {
-
-            const modalProjInfo = document.getElementById('modal-projectInfo')
-            
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
-
-            this.fillSlot("new-modal", this.modal.getElement());
-
-        })
+        
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -45,10 +45,23 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        // this.getElement().querySelector("").addEventListener("click", (e) => {
-        //     console.log('btn-project button pressed')
+        this.getElement().querySelector("#mol-img-text").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')
             
     
+            // const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+            // modalProjInfo.innerHTML = `
+            //     ${slot("new-modal")}
+            // `
+            // this.modal = new Modal_ProjectInfo(model.content)
+
+            // this.fillSlot("new-modal", this.modal.getElement());
+        });
+
+        // const molTextImgage = document.getElementById("#mol-img-text")
+        // molTextImgage.addEventListener("click", () => {
+
         //     const modalProjInfo = document.getElementById('modal-projectInfo')
             
         //     modalProjInfo.innerHTML = `
@@ -57,8 +70,7 @@ export function Template_Projects_View ( view )
         //     this.modal = new Modal_ProjectInfo(model.content)
 
         //     this.fillSlot("new-modal", this.modal.getElement());
-        // });
 
-        
+        // })
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -19,11 +19,13 @@ export function Template_Projects_View ( view )
             <div class="organism_btn-filled-pictures">
                 ${slot( "organismButtonFilledPictures")}
             </div>
-            <div id="modal-projectInfo">
+            
         </div>`;
     };
 
     // ${slot("projInfoModal")}
+
+    // <div id="modal-projectInfo"></div>
 
     this.bindScript = function ()
     {
@@ -42,17 +44,17 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')      
-            const modalProjInfo = document.getElementById('modal-projectInfo')
+        // this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
+        //     console.log('btn-project button pressed')      
+        //     const modalProjInfo = document.getElementById('modal-projectInfo')
             
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
+        //     modalProjInfo.innerHTML = `
+        //         ${slot("new-modal")}
+        //     `
+        //     this.modal = new Modal_ProjectInfo(model.content)
 
-            this.fillSlot("new-modal", this.modal.getElement());
-        });
+        //     this.fillSlot("new-modal", this.modal.getElement());
+        // });
 
 
     };

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -18,9 +18,8 @@ export function Template_Projects_View ( view )
             ${slot("organismNavbar")}
             <div class="organism_btn-filled-pictures">
                 ${slot( "organismButtonFilledPictures")}
-                
             </div>
-            
+            <div id="modal-projectInfo">
         </div>`;
     };
 

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -16,7 +16,7 @@ export function Template_Projects_View ( view )
         <div class="grid-template-projects">
             ${slot("organismNavbar")}
             ${slot( "organismButtonFilledPictures")}
-            <div id="modal-projectInfo">
+            <div id="modal-projectInfo"></div>
         </div>`;
     };
 

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -42,7 +42,7 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelector(".molecule_image-and-text").addEventListener("click", (e) => {
+        this.getElement().querySelectorAll(".molecule_image-and-text").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -32,11 +32,11 @@ export function Template_Projects_View ( view )
 
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
-        // let projInfoModal = new Modal_ProjectInfo(model.content)
-        // this.fillSlot("projInfoModal", projInfoModal.getElement())
-
-        let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
+        let projInfoModal = new Modal_ProjectInfo(model.content)
         this.fillSlot("projInfoModal", projInfoModal.getElement())
+
+        // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
+        // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -15,11 +15,15 @@ export function Template_Projects_View ( view )
     {
         return `
         <div class="grid-template-projects">
-        ${slot("organismNavbar")}
-            ${ slot( "organismButtonFilledPictures" ) }
-            ${slot("projInfoModal")}
+            ${slot("organismNavbar")}
+            <div class="organism_btn-filled-pictures">
+                ${slot( "organismButtonFilledPictures")}
+            </div>
+            <div id="modal-projectInfo">
         </div>`;
     };
+
+    // ${slot("projInfoModal")}
 
     this.bindScript = function ()
     {
@@ -32,11 +36,24 @@ export function Template_Projects_View ( view )
 
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
-        let projInfoModal = new Modal_ProjectInfo(model.content)
-        this.fillSlot("projInfoModal", projInfoModal.getElement())
+        // let projInfoModal = new Modal_ProjectInfo(model.content)
+        // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
+
+        this.getElement().querySelector(".organism_btn-filled-pictures").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')      
+            const modalProjInfo = document.getElementById('modal-projectInfo')
+            
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
+
 
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -49,14 +49,14 @@ export function Template_Projects_View ( view )
             console.log('btn-project button pressed')
             
     
-            // const modalProjInfo = document.getElementById('modal-projectInfo')
+            const modalProjInfo = document.getElementById('modal-projectInfo')
             
-            // modalProjInfo.innerHTML = `
-            //     ${slot("new-modal")}
-            // `
-            // this.modal = new Modal_ProjectInfo(model.content)
+            modalProjInfo.innerHTML = `
+                ${slot("new-modal")}
+            `
+            this.modal = new Modal_ProjectInfo(model.content)
 
-            // this.fillSlot("new-modal", this.modal.getElement());
+            this.fillSlot("new-modal", this.modal.getElement());
         });
 
         // const molTextImgage = document.getElementById("#mol-img-text")

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -42,7 +42,7 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelectorAll(".molecule_image-and-text").addEventListener("click", (e) => {
+        this.getElement().querySelectorAll("div.molecule_image-and-text").addEventListener("click", (e) => {
             console.log('btn-project button pressed')      
             const modalProjInfo = document.getElementById('modal-projectInfo')
             

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -4,6 +4,7 @@ import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_ButtonFilledPictures } from "../organisms/Organism_ButtonFilledPictures.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
+import { Organism_ProjectInfo } from "../organisms/Organism_ProjectInfo.mjs";
 
 export function Template_Projects_View ( view )
 {
@@ -31,7 +32,10 @@ export function Template_Projects_View ( view )
 
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
-        let projInfoModal = new Modal_ProjectInfo(model.content)
+        // let projInfoModal = new Modal_ProjectInfo(model.content)
+        // this.fillSlot("projInfoModal", projInfoModal.getElement())
+
+        let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         this.fillSlot("projInfoModal", projInfoModal.getElement())
 
     };

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -44,18 +44,18 @@ export function Template_Projects_View ( view )
         // let projInfoModal = new Organism_ProjectInfo(model.organism_projectInfo)
         // this.fillSlot("projInfoModal", projInfoModal.getElement())
 
-        this.getElement().querySelector("#mol-img-text").addEventListener("click", (e) => {
+        this.getElement().querySelector("#org-cards-container").addEventListener("click", (e) => {
             console.log('btn-project button pressed')
             
     
-            const modalProjInfo = document.getElementById('modal-projectInfo')
+            // const modalProjInfo = document.getElementById('modal-projectInfo')
             
-            modalProjInfo.innerHTML = `
-                ${slot("new-modal")}
-            `
-            this.modal = new Modal_ProjectInfo(model.content)
+            // modalProjInfo.innerHTML = `
+            //     ${slot("new-modal")}
+            // `
+            // this.modal = new Modal_ProjectInfo(model.content)
 
-            this.fillSlot("new-modal", this.modal.getElement());
+            // this.fillSlot("new-modal", this.modal.getElement());
         });
 
         // const molTextImgage = document.getElementById("#mol-img-text")

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -88,3 +88,7 @@
   justify-content: center;
   padding-bottom: 2em;
 }
+
+.modal-projInfo-image {
+  
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -89,6 +89,25 @@
   padding-bottom: 2em;
 }
 
+.modal-projectInfo-btn > button {
+  width: 68px;
+}
+
 .modal-projInfo-image {
-  
+  height: 141px;
+  width: 141px;
+}
+
+.modal-projInfo-image > img {
+  height: 100%;
+}
+
+.modal-projInfo-upper-section {
+  display: flex;
+  justify-content: end;
+  font-size: x-large;
+}
+
+.modal-projInfo-section-bg {
+  background-color: white;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -82,3 +82,9 @@
   height: 161px;
   margin: 0 41px 0 72px;
 }
+
+.modal-projectInfo-btn {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 2em;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -111,3 +111,7 @@
 .modal-projInfo-section-bg {
   background-color: white;
 }
+
+.modal-projectInfo{
+  width: 568px !important;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -106,10 +106,14 @@
   display: flex;
   justify-content: end;
   font-size: x-large;
+  margin-right: 0.5em;
+  padding-top: 0.5em;
 }
 
 .modal-projInfo-section-bg {
   background-color: white;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
 }
 
 .modal-projectInfo{

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -118,4 +118,5 @@
 
 .modal-projectInfo{
   width: 568px !important;
+  border-radius: 15px;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -174,3 +174,9 @@
     display:grid;
     grid-template-columns: auto auto;
 }
+
+.molecule_project-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -40,7 +40,6 @@
     width: 8rem;
     height: 8rem;
     background-color: #CCCCCC;
-    /* height: 15rem; */
 }
 
 .molecule_paginator {
@@ -226,7 +225,6 @@
 
 .molecule_heading-abt-img {
     display: flex;
-    /* justify-content: space-evenly; */
     margin: 0 2em 2em;
     gap: 100px;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -197,6 +197,7 @@
     width: 270px;
     margin: auto;
     justify-content: space-between;
+    margin-top: 1em;
 }
 
 .mol_checkbox-list-heading > .molecule-input-text{

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -37,8 +37,8 @@
     padding: 30px;
     gap: 20px;
     border: solid 1px black;
-    width: 9rem;
-    height: 9rem;
+    width: 8rem;
+    height: 8rem;
     background-color: #CCCCCC;
     /* height: 15rem; */
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -180,6 +180,7 @@
     justify-content: center;
     align-items: center;
     gap: 10px;
+    margin: 2.5em;
 }
 
 .molecule_project-state > p:nth-child(1n) {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -198,3 +198,17 @@
     margin: auto;
     gap: 9px;
 }
+
+.mol_checkbox-list-heading > .molecule-input-text{
+    display: flex;
+    gap: 10px;
+}
+
+.mol_checkbox-list-heading{
+    display: flex;
+    flex-direction: column; 
+}
+
+.molecule_list > ul{
+    padding: 0;
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -182,12 +182,19 @@
     gap: 10px;
 }
 
-.molecule_project-state:nth-child(1n) {
+.molecule_project-state > p:nth-child(1n) {
     border: 1px solid black;
-    padding: 10px;
+    padding: 15px;
 }
 
-.molecule_project-state:nth-last-child(3) {
+.molecule_project-state > p:nth-last-child(3) {
     background-color: #CCCCCC;
     border: none !important;
+}
+
+.molecule-proj_info-checkboxes {
+    display: flex;
+    width: 287px;
+    margin: auto;
+    gap: 9px;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -209,6 +209,15 @@
     flex-direction: column; 
 }
 
-.molecule_list > ul{
+.molecule_list-wrapper > ul{
     padding: 0;
+}
+
+.molecule_list-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.molecule_list-wrapper > h4 { 
+    align-self: center;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -194,14 +194,17 @@
 
 .molecule-proj_info-checkboxes {
     display: flex;
-    width: 287px;
+    width: 270px;
     margin: auto;
-    gap: 9px;
+    justify-content: space-between;
+    margin-top: 1em;
+
 }
 
 .mol_checkbox-list-heading > .molecule-input-text{
     display: flex;
     gap: 10px;
+    margin-bottom: 1em;
 }
 
 .mol_checkbox-list-heading{

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -223,6 +223,11 @@
     align-self: center;
 }
 
-.mol_heading-abt {
-    
+.molecule_heading-abt-img {
+    display: flex;
+    justify-content: space-around;
+}
+
+.mol_heading-abt > p {
+    padding: 0 !important;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -222,3 +222,7 @@
 .molecule_list-wrapper > h4 { 
     align-self: center;
 }
+
+.mol_heading-abt {
+    
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -197,14 +197,11 @@
     width: 270px;
     margin: auto;
     justify-content: space-between;
-    margin-top: 1em;
-
 }
 
 .mol_checkbox-list-heading > .molecule-input-text{
     display: flex;
     gap: 10px;
-    margin-bottom: 1em;
 }
 
 .mol_checkbox-list-heading{

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -179,4 +179,15 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: 10px;
+}
+
+.molecule_project-state:nth-child(1n) {
+    border: 1px solid black;
+    padding: 10px;
+}
+
+.molecule_project-state:nth-last-child(3) {
+    background-color: #CCCCCC;
+    border: none !important;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -225,9 +225,16 @@
 
 .molecule_heading-abt-img {
     display: flex;
-    justify-content: space-around;
+    /* justify-content: space-evenly; */
+    margin: 0 2em 2em;
+    gap: 100px;
 }
 
 .mol_heading-abt > p {
     padding: 0 !important;
+}
+
+.mol_heading-abt {
+    margin-left: 4em;
+    margin-top: 1em;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -35,10 +35,12 @@
     justify-content: center;
     align-items: center;
     padding: 30px;
-    /* gap: 20px; */
+    gap: 20px;
     border: solid 1px black;
     width: 9rem;
-    height: 15rem;
+    height: 9rem;
+    background-color: #CCCCCC;
+    /* height: 15rem; */
 }
 
 .molecule_paginator {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -33,18 +33,19 @@
 
 #organism_buttonFilledPicture_btnParent > button {
     width: 107px;
+    margin-left: 2.5em;
 }
 
 .organism_buttonFilledcards {
     /* display: grid; */
     grid-area: 2 / 1 / 2 / 1;
     overflow-y: scroll;
-    height: 412px;
+    height: 430px;
     display: flex;
-    gap: 50px;
+    gap: 46px;
     flex-wrap: wrap;
     /* flex-flow: wrap; */
-    width: 891px;
+    width: 933px;
     padding: 0 1em;
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -171,6 +171,5 @@ nav > ul {
 }
 
 .organism_project_info {
-    width: 568px;
     padding-top: 2em;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -49,7 +49,7 @@
     padding: 0 1em;
 }
 
-.organism_buttonFilledcards ::-webkit-scrollbar-track {
+.organism_buttonFilledcards::-webkit-scrollbar-track {
     background: none; 
 }
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -169,3 +169,8 @@ nav > ul {
     height: 500px;
     width: 80%;
 }
+
+.organism_project_info {
+    width: 568px;
+    padding-top: 2em;
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -20,15 +20,8 @@
     margin-top: 5em;
 }
 
-/* .organism_buttonFilledPicture_wrapper::before {
-    content: '';
-    grid-area: 1 / 1 / 2 / 5;
-    display: grid;
-  } */
-
 #organism_buttonFilledPicture_btnParent {
     grid-area: 1 / 4 / 1 / 4;
-    /* display: grid; */
 }
 
 #organism_buttonFilledPicture_btnParent > button {
@@ -37,14 +30,12 @@
 }
 
 .organism_buttonFilledcards {
-    /* display: grid; */
     grid-area: 2 / 1 / 2 / 1;
     overflow-y: scroll;
     height: 430px;
     display: flex;
     gap: 46px;
     flex-wrap: wrap;
-    /* flex-flow: wrap; */
     width: 933px;
     padding: 0 1em;
 }
@@ -110,7 +101,6 @@ nav > ul {
     justify-content: space-between;
     justify-items: center;
     align-items: center;
-    /* padding-left: 1rem; */
 }
 
 .organism_list-all-search__top > h2{
@@ -162,7 +152,6 @@ nav > ul {
     margin-left: 10px;
     margin-bottom: 40px;
 }
-
 
 .overflow-container {
     overflow-y: scroll;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -29,6 +29,10 @@
     display: grid;
 }
 
+.organism_buttonFilledPicture_wrapper > div {
+    cursor: pointer;
+}
+
 .organism_start-info > *:nth-child(2) {
     max-width: 400px;
     justify-self: center;

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -49,6 +49,10 @@
     padding: 0 1em;
 }
 
+.organism_buttonFilledcards ::-webkit-scrollbar-track {
+    background: none; 
+}
+
 .organism_buttonFilledPicture_wrapper > div {
     cursor: pointer;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -172,4 +172,6 @@ nav > ul {
 
 .organism_project_info {
     padding-top: 2em;
+    border-bottom-right-radius: 15px;
+    border-bottom-left-radius: 15px;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -12,26 +12,40 @@
 
 .organism_buttonFilledPicture_wrapper {
     display: grid;
-    /* grid-template-columns: repeat(4, 206px); */
-    /* grid-auto-rows: minmax(20px, auto);
+    grid-template-columns: repeat(4, 206px);
+    grid-auto-rows: minmax(20px, auto);
     gap: 50px;
-    justify-content: center; */
+    justify-content: center;
+    padding: 2em;
+    margin-top: 5em;
 }
 
-.organism_buttonFilledPicture_wrapper::before {
+/* .organism_buttonFilledPicture_wrapper::before {
     content: '';
     grid-area: 1 / 1 / 2 / 5;
     display: grid;
-  }
+  } */
 
 #organism_buttonFilledPicture_btnParent {
-    grid-area: 1 / 4 / 2 / 4;
-    display: grid;
+    grid-area: 1 / 4 / 1 / 4;
+    /* display: grid; */
+}
+
+#organism_buttonFilledPicture_btnParent > button {
+    width: 107px;
 }
 
 .organism_buttonFilledcards {
-    display: grid;
-    grid-area: 3 / 3/ 3 / 5;
+    /* display: grid; */
+    grid-area: 2 / 1 / 2 / 1;
+    overflow-y: scroll;
+    height: 412px;
+    display: flex;
+    gap: 50px;
+    flex-wrap: wrap;
+    /* flex-flow: wrap; */
+    width: 891px;
+    padding: 0 1em;
 }
 
 .organism_buttonFilledPicture_wrapper > div {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -12,10 +12,10 @@
 
 .organism_buttonFilledPicture_wrapper {
     display: grid;
-    grid-template-columns: repeat(4, 206px);
-    grid-auto-rows: minmax(20px, auto);
+    /* grid-template-columns: repeat(4, 206px); */
+    /* grid-auto-rows: minmax(20px, auto);
     gap: 50px;
-    justify-content: center;
+    justify-content: center; */
 }
 
 .organism_buttonFilledPicture_wrapper::before {
@@ -27,6 +27,11 @@
 #organism_buttonFilledPicture_btnParent {
     grid-area: 1 / 4 / 2 / 4;
     display: grid;
+}
+
+.organism_buttonFilledcards {
+    display: grid;
+    grid-area: 3 / 3/ 3 / 5;
 }
 
 .organism_buttonFilledPicture_wrapper > div {


### PR DESCRIPTION
UC-98-add-project-info-modal-and-create-content-to-it-to-project-view


## Description & motivation

Creating a modal for project view.
No other functionality added execept for adding eventlisteners. 



## How to test

Switch to branch #UC-98-add-project-info-modal-and-create-content-to-it-to-project-view in UrbanCloud.
Build and start project. 
Click on a card to see modal. 



## New tickets to be added

Functionalities for this ticket.



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
