### PR TITLE
Uc 93 add modal to information in organisation view

### DIFF
--- a/generics/components/molecules/Molecule_ModalOrgInputAndOutput.mjs
+++ b/generics/components/molecules/Molecule_ModalOrgInputAndOutput.mjs
@@ -1,0 +1,40 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Icon } from "../atoms/Atom_Icon.mjs";
+import { Molecule_List } from "./Molecule_List.mjs";
+import { Molecule_HeaderAndText } from "../molecules/Molecule_HeaderAndText.mjs"
+
+export function Molecule_ModalOrgInputAndOutput(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_modal_org_in-output">
+                ${slot("box1")}
+                ${slot("icon1")}
+                ${slot("box2")}
+                ${slot("icon2")}
+                ${slot("box3")}
+            </div>
+        `
+    }
+
+    this.bindScript= function() {
+        let box1 = new Molecule_List(model.lists1)
+        this.fillSlot("box1", box1.getElement());
+
+        let icon1 = new Atom_Icon(model.atom_icon1)
+        this.fillSlot("icon1", icon1.getElement());
+
+        let box2 = new Molecule_HeaderAndText(model.molecule_headerAndText)
+        this.fillSlot("box2", box2.getElement());
+
+        let icon2 = new Atom_Icon(model.atom_icon2)
+        this.fillSlot("icon2", icon2.getElement());
+
+        let box3 = new Molecule_List(model.lists2)
+        this.fillSlot("box3", box3.getElement());
+    }
+
+}

--- a/generics/components/molecules/Molecule_ModalOrganisationLists.mjs
+++ b/generics/components/molecules/Molecule_ModalOrganisationLists.mjs
@@ -1,0 +1,30 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Icon } from "../atoms/Atom_Icon.mjs";
+import { Molecule_List } from "./Molecule_List.mjs";
+
+export function Molecule_ModalOrganisationLists(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_modal_org_lists">
+                ${slot("list1")}
+                ${slot("list2")}
+                ${slot("list3")}
+            </div>
+        `
+    }
+
+    this.bindScript= function() {
+        let list1 = new Molecule_List(model.lists1)
+        this.fillSlot("list1", list1.getElement());
+
+        let list2 = new Molecule_List(model.lists2)
+        this.fillSlot("list2", list2.getElement());
+
+        let list3 = new Molecule_List(model.lists3)
+        this.fillSlot("list3", list3.getElement());
+    }
+}

--- a/generics/components/organisms/Modal_OrganisationListAll.mjs
+++ b/generics/components/organisms/Modal_OrganisationListAll.mjs
@@ -13,8 +13,8 @@ export function Modal_OrganisationListAll(model) {
         return `
         <div id="modal-background" class="modal">
             <div class="modal-container modal-process-inner-wrap">
-                <div class="modal-process-section">
-                    <div class="modal-process-upper-section">
+                <div class="modal-org-section">
+                    <div class="modal-organisation-upper-section">
                         <i class="bi bi-x"></i>
                     </div>
                 </div> 

--- a/generics/components/organisms/Modal_OrganisationListAll.mjs
+++ b/generics/components/organisms/Modal_OrganisationListAll.mjs
@@ -1,0 +1,58 @@
+import {slot} from "../../../core/helpers.mjs";
+import {Component} from "../../../core/Component.mjs";
+import { Organism_OrganisationModal } from "./Organism_OrganisationModal.mjs";
+
+
+export function Modal_OrganisationListAll(model) {
+    Component.call(this)
+
+    this.content = model.content;
+    this.modal = null;
+
+    this.getHtml = function() {
+        return `
+        <div id="modal-background" class="modal">
+            <div class="modal-container modal-process-inner-wrap">
+                <div class="modal-process-section">
+                    <div class="modal-process-upper-section">
+                        <i class="bi bi-x"></i>
+                    </div>
+                </div> 
+                ${slot("content")}
+            </div>
+        </div>
+        `
+    }
+
+    this.bindScript= function() {
+        this.content = new Organism_OrganisationModal(model.organism_organisation_modal)
+        this.fillSlot("content", this.content.getElement());
+
+        const mStyle = this.getElement().style
+        mStyle.position = "absolute"
+        mStyle.width = window.innerWidth + "px"
+        mStyle.height = window.innerHeight + "px"
+        mStyle.top = "0px"
+        mStyle.left = "0px"
+        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        mStyle.display = "flex"
+        mStyle.justifyContent = "center"
+        mStyle.alignItems = "center"
+
+        this.content.getElement().style.backgroundColor = "white"
+
+        this.getElement().addEventListener("click", (e)=>{
+            if(e.target === this.getElement()){
+                this.getElement().remove()
+            }
+        })
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelector('#modal-background').remove()
+        });
+    }
+
+    this.show= function() {
+        document.body.append(this.getElement())
+    }
+}

--- a/generics/components/organisms/Modal_OrganisationListAll.mjs
+++ b/generics/components/organisms/Modal_OrganisationListAll.mjs
@@ -12,7 +12,7 @@ export function Modal_OrganisationListAll(model) {
     this.getHtml = function() {
         return `
         <div id="modal-background" class="modal">
-            <div class="modal-container modal-process-inner-wrap">
+            <div class="modal-container modal-organisation-inner-wrap">
                 <div class="modal-org-section">
                     <div class="modal-organisation-upper-section">
                         <i class="bi bi-x"></i>

--- a/generics/components/organisms/Organism_ListAll.mjs
+++ b/generics/components/organisms/Organism_ListAll.mjs
@@ -21,7 +21,7 @@ export function Organism_ListAll (model){
                     </div>
                     
                 </div>
-                <div class="organism_list-all-search__lists">
+                <div id="organism_all_lists" class="organism_list-all-search__lists">
                     ${slot('list1')}
                     ${slot('list2')}
                     ${slot('list3')}

--- a/generics/components/organisms/Organism_OrganisationModal.mjs
+++ b/generics/components/organisms/Organism_OrganisationModal.mjs
@@ -1,0 +1,28 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Molecule_ModalOrgInputAndOutput } from "../molecules/Molecule_ModalOrgInputAndOutput.mjs";
+import { Molecule_ModalOrganisationLists } from "../molecules/Molecule_ModalOrganisationLists.mjs";
+
+
+export function Organism_OrganisationModal(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="organism_organisation-modal">
+                ${slot("inputProcOutput")}
+                ${slot("lists")}
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+
+        let inputProcOutput = new Molecule_ModalOrgInputAndOutput(model.molecule_modalOrg_InputOutput)
+        this.fillSlot("inputProcOutput", inputProcOutput.getElement());
+
+        let lists = new Molecule_ModalOrganisationLists(model.molecule_modalOrg_lists)
+        this.fillSlot("lists", lists.getElement());
+    }
+}

--- a/generics/components/organisms/Organism_OrganisationModal.mjs
+++ b/generics/components/organisms/Organism_OrganisationModal.mjs
@@ -1,5 +1,6 @@
 import {Component} from "../../../core/Component.mjs";
 import {slot} from "../../../core/helpers.mjs";
+import { Atom_Icon } from "../atoms/Atom_Icon.mjs";
 import { Molecule_ModalOrgInputAndOutput } from "../molecules/Molecule_ModalOrgInputAndOutput.mjs";
 import { Molecule_ModalOrganisationLists } from "../molecules/Molecule_ModalOrganisationLists.mjs";
 
@@ -12,6 +13,7 @@ export function Organism_OrganisationModal(model) {
         return `
             <div class="organism_organisation-modal">
                 ${slot("inputProcOutput")}
+                ${slot("icon")}
                 ${slot("lists")}
             </div>
         ` 
@@ -24,5 +26,8 @@ export function Organism_OrganisationModal(model) {
 
         let lists = new Molecule_ModalOrganisationLists(model.molecule_modalOrg_lists)
         this.fillSlot("lists", lists.getElement());
+
+        let icon = new Atom_Icon(model.atom_icon)
+        this.fillSlot("icon", icon.getElement());
     }
 }

--- a/generics/components/templates/Template_ListAllOrganisation_Model.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_Model.mjs
@@ -139,6 +139,9 @@ export function Template_ListAllOrganisation_Model(model) {
                                 items : model.items3
                             }
                         },
+                        atom_icon : {
+                            icon : model.icon8
+                        },
                         molecule_modalOrg_lists : {
                             lists1 : {
                                 atom_heading4 : {

--- a/generics/components/templates/Template_ListAllOrganisation_Model.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_Model.mjs
@@ -108,7 +108,59 @@ export function Template_ListAllOrganisation_Model(model) {
                         },
                         items : model.items
                     }   
-                }
+                },
+                content : {
+                    organism_organisation_modal : {
+                        molecule_modalOrg_InputOutput : {
+                            lists1 : {
+                                atom_heading4 : {
+                                    text : model.listHeading4
+                                },
+                                items : model.items2
+                            },
+                            atom_icon1 : {
+                                icon : model.icon6
+                            },
+                            molecule_headerAndText : {
+                                atom_heading4 : {
+                                    text : model.centerText
+                                },
+                                atom_text1 : {
+                                    text : model.centerAbout
+                                },
+                            },
+                            atom_icon2 : {
+                                icon : model.icon7
+                            },
+                            lists2 : {
+                                atom_heading4 : {
+                                    text : model.listHeading5
+                                },
+                                items : model.items3
+                            }
+                        },
+                        molecule_modalOrg_lists : {
+                            lists1 : {
+                                atom_heading4 : {
+                                    text : model.listHeading6
+                                },
+                                items : model.items4
+                            },
+                            lists2 : {
+                                atom_heading4 : {
+                                    text : model.listHeading7
+                                },
+                                items : model.items4
+                            },
+                            lists3 : {
+                                atom_heading4 : {
+                                    text : model.listHeading8
+                                },
+                                items : model.items4
+                            }
+                        }
+                    }
+                }   
             }
         }
 

--- a/generics/components/templates/Template_ListAllOrganisation_View.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_View.mjs
@@ -25,8 +25,7 @@ export function Template_ListAllOrganisation_View(view){
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         this.fillSlot("organismListAll", organism_listAll.getElement())
 
-        this.getElement().querySelector("#organism_all_lists").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')     
+        this.getElement().querySelector("#organism_all_lists").addEventListener("click", (e) => {    
 
             const modalId = document.getElementById('modal-organisationView')
             

--- a/generics/components/templates/Template_ListAllOrganisation_View.mjs
+++ b/generics/components/templates/Template_ListAllOrganisation_View.mjs
@@ -3,6 +3,7 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs";
 import { Organism_ListAll } from "../organisms/Organism_ListAll.mjs";
+import { Modal_OrganisationListAll } from "../organisms/Modal_OrganisationListAll.mjs";
 
 export function Template_ListAllOrganisation_View(view){
     
@@ -12,6 +13,7 @@ export function Template_ListAllOrganisation_View(view){
         return `<div>
             ${slot("organismNavbar")}
             ${slot("organismListAll")}
+            <div id="modal-organisationView"></div>
         </div>`
     }
 
@@ -22,5 +24,20 @@ export function Template_ListAllOrganisation_View(view){
 
         this.fillSlot("organismNavbar", organismNavbar.getElement())
         this.fillSlot("organismListAll", organism_listAll.getElement())
+
+        this.getElement().querySelector("#organism_all_lists").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')     
+
+            const modalId = document.getElementById('modal-organisationView')
+            
+            modalId.innerHTML = `
+                <div>
+                    ${slot("new-modal")}
+                </div>
+                `
+            this.modal = new Modal_OrganisationListAll(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
     }
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -90,6 +90,7 @@
   background-color: white;
   border-top-right-radius: 15px;
   border-top-left-radius: 15px;
+  padding-right: 0.2em;
 }
 
 .modal-organisation-inner-wrap {

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -88,4 +88,10 @@
   justify-content: end;
   font-size: x-large;
   background-color: white;
+  border-top-right-radius: 15px;
+  border-top-left-radius: 15px;
+}
+
+.modal-organisation-inner-wrap {
+  width: unset;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -82,3 +82,10 @@
   height: 161px;
   margin: 0 41px 0 72px;
 }
+
+.modal-organisation-upper-section {
+  display: flex;
+  justify-content: end;
+  font-size: x-large;
+  background-color: white;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -94,4 +94,5 @@
 
 .modal-organisation-inner-wrap {
   width: unset;
+  border: none !important;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -216,33 +216,17 @@
     font-size: xx-large;
 }
 
-
-
-
-.molecule_modal-proc-children {
+.molecule_modal_org_lists {
     display: flex;
     justify-content: center;
-    align-items: center;
     gap: 10px;
 }
 
-.molecule_modal-proc-children > h4:nth-child(1n){
-    border: 1px solid black;
-    padding: 21px;
-    width: 74px;
-}
-
-.molecule_modal-proc-children > i:nth-child(1n) {
-    font-size: xx-large;
-}
-
-.molecule_modal-proc-third-section {
+.molecule_modal_org_lists > div > ul {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    padding-top: 0;
+    padding: 17px;
 }
 
-.molecule_modal-proc-third-section > i { 
-    font-size: xx-large;
-}
+
+

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -173,12 +173,6 @@
     grid-template-columns: auto auto;
 }
 
-
-
-
-
-
-
 .molecule_modal_org_in-output {
     display: flex;
     align-items: center;
@@ -223,6 +217,7 @@
     gap: 71px;
     margin: auto;
     width: 468px;
+    margin-top: 1em;
 }
 
 .molecule_modal_org_lists > div{

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -172,3 +172,77 @@
     display:grid;
     grid-template-columns: auto auto;
 }
+
+
+
+
+
+
+
+.molecule_modal_org_in-output {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+
+.molecule_modal_org_in-output > .molecule_header-and-text {
+    align-content: unset !important;
+}
+
+.molecule_modal_org_in-output > .molecule_header-and-text > p {
+    padding: 0;
+}
+
+.molecule_modal_org_in-output > div:nth-child(1n){
+    border: 1px solid black;
+    padding: 2em;
+}
+
+.molecule_modal_org_in-output > div > ul {
+    display: flex;
+    flex-direction: column;
+    padding: 17px;
+}
+
+.molecule_modal_org_in-output > div:nth-last-child(3){
+    background-color: #CCCCCC;
+    border: none !important;
+    width: 400px;
+    height: 266px;
+}
+
+.molecule_modal_org_in-output > i:nth-child(1n) {
+    font-size: xx-large;
+}
+
+
+
+
+.molecule_modal-proc-children {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+}
+
+.molecule_modal-proc-children > h4:nth-child(1n){
+    border: 1px solid black;
+    padding: 21px;
+    width: 74px;
+}
+
+.molecule_modal-proc-children > i:nth-child(1n) {
+    font-size: xx-large;
+}
+
+.molecule_modal-proc-third-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 0;
+}
+
+.molecule_modal-proc-third-section > i { 
+    font-size: xx-large;
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -209,8 +209,8 @@
 .molecule_modal_org_in-output > div:nth-last-child(3){
     background-color: #CCCCCC;
     border: none !important;
-    width: 400px;
-    height: 266px;
+    width: 411px;
+    height: 283px;
 }
 
 .molecule_modal_org_in-output > i:nth-child(1n) {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -197,6 +197,7 @@
 .molecule_modal_org_in-output > div:nth-child(1n){
     border: 1px solid black;
     padding: 2em;
+    width: 100px;
 }
 
 .molecule_modal_org_in-output > div > ul {
@@ -219,11 +220,13 @@
 .molecule_modal_org_lists {
     display: flex;
     justify-content: center;
-    gap: 10px;
+    gap: 71px;
+    margin: auto;
+    width: 468px;
 }
 
 .molecule_modal_org_lists > div{
-    width: 140px;
+    width: 129px;
 }
 
 .molecule_modal_org_lists > div > ul {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -222,10 +222,14 @@
     gap: 10px;
 }
 
+.molecule_modal_org_lists > div{
+    width: 140px;
+}
+
 .molecule_modal_org_lists > div > ul {
     display: flex;
     flex-direction: column;
-    padding: 17px;
+    padding: 26px;
 }
 
 

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -143,7 +143,15 @@ nav > ul {
 }
 
 .organism_organisation-modal {
-    padding: 5em;
+    padding: 2em;
     border-bottom-left-radius: 15px;
     border-bottom-right-radius: 15px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 1045px;
+}
+
+.organism_organisation-modal > i {
+    font-size: xx-large;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -8,8 +8,6 @@
     grid-template-rows: auto 1fr;
 }
 
-.organism_login-or-signup {}
-
 .organism_buttonFilledPicture_wrapper {
     display: grid;
     grid-template-columns: repeat(4, 206px);

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -141,3 +141,9 @@ nav > ul {
     height: 500px;
     width: 80%;
 }
+
+.organism_organisation-modal {
+    padding: 5em;
+    border-bottom-left-radius: 15px;
+    border-bottom-right-radius: 15px;
+}


### PR DESCRIPTION
 UC-93-add-modal-to-information-in-organisation-view


## Description & motivation

Creating a modal to information in organisation view.
- new organism with new molecules added to the modal.



## How to test

Add # UC-93-add-modal-to-information-in-organisation-view at the end of "nd_frontend" in package.json at UrbanCloud
Run and start the project.
Go to view /organisation.
Click on a list item. Modal should pop up.




## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
