### PR TITLE
Uc 91 add add project modal to project view

### DIFF
--- a/generics/components/molecules/Molecule_TextAndInput.mjs
+++ b/generics/components/molecules/Molecule_TextAndInput.mjs
@@ -1,0 +1,26 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Atom_Input } from "../atoms/Atom_Input.mjs";
+import { Atom_Text1 } from "../atoms/Atom_Text1.mjs";
+
+export function Molecule_TextAndInput(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="molecule_text_input">
+                ${slot("text")}
+                ${slot("input")}
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+        let text = new Atom_Text1(model.atom_text1)
+        this.fillSlot("text", text.getElement());
+
+        let input = new Atom_Input(model.atom_input)
+        this.fillSlot("input", input.getElement());
+    }
+}

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -12,7 +12,7 @@ export function Modal_AddProjectProjectsView(model) {
     this.getHtml = function() {
         return `
         <div id="modal-background" class="modal">
-            <div class="modal-container modal-process-inner-wrap">
+            <div class="modal-container modal-btn_project-inner-wrap">
                 <div class="modal-process-section">
                     <div class="modal-process-upper-section">
                         <i class="bi bi-x"></i>

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -2,7 +2,6 @@ import {slot} from "../../../core/helpers.mjs";
 import {Component} from "../../../core/Component.mjs";
 import { Organism_BtnPositiveAddToProject } from "./Organism_BtnPositiveAddToProject.mjs";
 
-
 export function Modal_AddProjectProjectsView(model) {
     Component.call(this)
 

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -12,7 +12,7 @@ export function Modal_AddProjectProjectsView(model) {
     this.getHtml = function() {
         return `
         <div id="modal-background" class="modal">
-            <div class="modal-container modal-btn_project-inner-wrap">
+            <div class="modal-btn_project-inner-wrap">
                 <div class="modal-process-section">
                     <div class="modal-process-upper-section">
                         <i class="bi bi-x"></i>
@@ -23,6 +23,8 @@ export function Modal_AddProjectProjectsView(model) {
         </div>
         `
     }
+
+    // modal-container 
 
     this.bindScript= function() {
         this.content = new Organism_BtnPositiveAddToProject(model.organism_btn_positive_add_proj)

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -13,7 +13,7 @@ export function Modal_AddProjectProjectsView(model) {
         return `
         <div id="modal-background" class="modal">
             <div class="modal-btn_project-inner-wrap">
-                <div class="modal-process-section">
+                <div class="modal-btn_proj-section">
                     <div class="modal-process-upper-section">
                         <i class="bi bi-x"></i>
                     </div>

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -1,0 +1,58 @@
+import {slot} from "../../../core/helpers.mjs";
+import {Component} from "../../../core/Component.mjs";
+import { Organism_BtnPositiveAddToProject } from "./Organism_btnPositiveAddToProject.mjs";
+
+
+export function Modal_AddProjectProjectsView(model) {
+    Component.call(this)
+
+    this.content = model.content;
+    this.modal = null;
+
+    this.getHtml = function() {
+        return `
+        <div id="modal-background" class="modal">
+            <div class="modal-container modal-process-inner-wrap">
+                <div class="modal-process-section">
+                    <div class="modal-process-upper-section">
+                        <i class="bi bi-x"></i>
+                    </div>
+                </div> 
+                ${slot("content")}
+            </div>
+        </div>
+        `
+    }
+
+    this.bindScript= function() {
+        this.content = new Organism_BtnPositiveAddToProject(model.organism_btn_positive_add_proj)
+        this.fillSlot("content", this.content.getElement());
+
+        const mStyle = this.getElement().style
+        mStyle.position = "absolute"
+        mStyle.width = window.innerWidth + "px"
+        mStyle.height = window.innerHeight + "px"
+        mStyle.top = "0px"
+        mStyle.left = "0px"
+        mStyle.backgroundColor = "rgba(0,0,0,0.5)"
+        mStyle.display = "flex"
+        mStyle.justifyContent = "center"
+        mStyle.alignItems = "center"
+
+        this.content.getElement().style.backgroundColor = "white"
+
+        this.getElement().addEventListener("click", (e)=>{
+            if(e.target === this.getElement()){
+                this.getElement().remove()
+            }
+        })
+
+        this.getElement().querySelector(".bi-x").addEventListener("click", (e) => {
+            document.querySelector('#modal-background').remove()
+        });
+    }
+
+    this.show= function() {
+        document.body.append(this.getElement())
+    }
+}

--- a/generics/components/organisms/Modal_AddProjectProjectsView.mjs
+++ b/generics/components/organisms/Modal_AddProjectProjectsView.mjs
@@ -1,6 +1,6 @@
 import {slot} from "../../../core/helpers.mjs";
 import {Component} from "../../../core/Component.mjs";
-import { Organism_BtnPositiveAddToProject } from "./Organism_btnPositiveAddToProject.mjs";
+import { Organism_BtnPositiveAddToProject } from "./Organism_BtnPositiveAddToProject.mjs";
 
 
 export function Modal_AddProjectProjectsView(model) {

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -1,7 +1,7 @@
 import {Component} from "../../../core/Component.mjs";
 import {slot} from "../../../core/helpers.mjs";
 import { Molecule_TextAndInput } from "../molecules/Molecule_TextAndInput.mjs";
-import { Molecule_textAndDropDown } from "../molecules/Molecule_textAndDropDown.mjs";
+import { Molecule_textAndDropDown } from "../molecules/Molecule_TextAndDropDown.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -1,7 +1,7 @@
 import {Component} from "../../../core/Component.mjs";
 import {slot} from "../../../core/helpers.mjs";
 import { Molecule_TextAndInput } from "../molecules/Molecule_TextAndInput.mjs";
-import { Molecule_TextAndDropDown } from "../molecules/Molecule_TextAndDropDown.mjs";
+import { Molecule_TextAndDropdown } from "../molecules/Molecule_TextAndDropdown.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
@@ -34,7 +34,7 @@ export function Organism_BtnPositiveAddToProject(model) {
         let textInput2 = new Molecule_TextAndInput(model.molecule_text_input2)
         this.fillSlot("textInput2", textInput2.getElement());
 
-        let textDropDown = new Molecule_TextAndDropDown(model.molecule_text_dropdown)
+        let textDropDown = new Molecule_TextAndDropdown(model.molecule_text_dropdown)
         this.fillSlot("textDropDown", textDropDown.getElement());
 
         let picture = new Atom_Image(model.atom_image)

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -1,7 +1,7 @@
 import {Component} from "../../../core/Component.mjs";
 import {slot} from "../../../core/helpers.mjs";
 import { Molecule_TextAndInput } from "../molecules/Molecule_TextAndInput.mjs";
-import { Molecule_textAndDropDown } from "../molecules/Molecule_TextAndDropDown.mjs";
+import { Molecule_TextAndDropDown } from "../molecules/Molecule_TextAndDropDown.mjs";
 import { Atom_Image } from "../atoms/Atom_Image.mjs";
 import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
 
@@ -34,7 +34,7 @@ export function Organism_BtnPositiveAddToProject(model) {
         let textInput2 = new Molecule_TextAndInput(model.molecule_text_input2)
         this.fillSlot("textInput2", textInput2.getElement());
 
-        let textDropDown = new Molecule_textAndDropDown(model.molecule_text_dropdown)
+        let textDropDown = new Molecule_TextAndDropDown(model.molecule_text_dropdown)
         this.fillSlot("textDropDown", textDropDown.getElement());
 
         let picture = new Atom_Image(model.atom_image)

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -18,14 +18,17 @@ export function Organism_BtnPositiveAddToProject(model) {
                         ${slot("textInput2")}
                         ${slot("textDropDown")}
                     </div>
-                    <div class="modal-btn_proj_image">
                         ${slot("picture")}
-                    </div>
+                    
                 </div>
                         ${slot("btnPositive")}
             </div>
         ` 
     }
+
+    // <div class="modal-btn_proj_image">
+    //                     ${slot("picture")}
+    //                 </div>
 
     this.bindScript= function() {
         let textInput1 = new Molecule_TextAndInput(model.molecule_text_input1)

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -13,14 +13,14 @@ export function Organism_BtnPositiveAddToProject(model) {
         return `
             <div class="organism_btn_projects_modal">
                 <div class="modal_btn_projects_first_section">
-                <div class="molecule_text_input_dropdown">
-                    ${slot("textInput1")}
-                    ${slot("textInput2")}
-                    ${slot("textDropDown")}
+                    <div class="molecule_text_input_dropdown">
+                        ${slot("textInput1")}
+                        ${slot("textInput2")}
+                        ${slot("textDropDown")}
+                    </div>
+                        ${slot("picture")}
                 </div>
-                    ${slot("picture")}
-                </div>
-                    ${slot("btnPositive")}
+                        ${slot("btnPositive")}
             </div>
         ` 
     }

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -18,17 +18,14 @@ export function Organism_BtnPositiveAddToProject(model) {
                         ${slot("textInput2")}
                         ${slot("textDropDown")}
                     </div>
+                    <div class="modal-btn_proj_image">
                         ${slot("picture")}
-                    
+                    </div>
                 </div>
                         ${slot("btnPositive")}
             </div>
         ` 
     }
-
-    // <div class="modal-btn_proj_image">
-    //                     ${slot("picture")}
-    //                 </div>
 
     this.bindScript= function() {
         let textInput1 = new Molecule_TextAndInput(model.molecule_text_input1)

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -18,7 +18,9 @@ export function Organism_BtnPositiveAddToProject(model) {
                         ${slot("textInput2")}
                         ${slot("textDropDown")}
                     </div>
+                    <div class="modal-btn_proj_image">
                         ${slot("picture")}
+                    </div>
                 </div>
                         ${slot("btnPositive")}
             </div>

--- a/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
+++ b/generics/components/organisms/Organism_BtnPositiveAddToProject.mjs
@@ -1,0 +1,44 @@
+import {Component} from "../../../core/Component.mjs";
+import {slot} from "../../../core/helpers.mjs";
+import { Molecule_TextAndInput } from "../molecules/Molecule_TextAndInput.mjs";
+import { Molecule_textAndDropDown } from "../molecules/Molecule_textAndDropDown.mjs";
+import { Atom_Image } from "../atoms/Atom_Image.mjs";
+import { Atom_ButtonPositive } from "../atoms/Atom_ButtonPositive.mjs";
+
+export function Organism_BtnPositiveAddToProject(model) {
+    Component.call(this)
+
+    this.getHtml = function() {
+
+        return `
+            <div class="organism_btn_projects_modal">
+                <div class="modal_btn_projects_first_section">
+                <div class="molecule_text_input_dropdown">
+                    ${slot("textInput1")}
+                    ${slot("textInput2")}
+                    ${slot("textDropDown")}
+                </div>
+                    ${slot("picture")}
+                </div>
+                    ${slot("btnPositive")}
+            </div>
+        ` 
+    }
+
+    this.bindScript= function() {
+        let textInput1 = new Molecule_TextAndInput(model.molecule_text_input1)
+        this.fillSlot("textInput1", textInput1.getElement());
+
+        let textInput2 = new Molecule_TextAndInput(model.molecule_text_input2)
+        this.fillSlot("textInput2", textInput2.getElement());
+
+        let textDropDown = new Molecule_textAndDropDown(model.molecule_text_dropdown)
+        this.fillSlot("textDropDown", textDropDown.getElement());
+
+        let picture = new Atom_Image(model.atom_image)
+        this.fillSlot("picture", picture.getElement());
+
+        let btnPositive = new Atom_ButtonPositive(model.atom_button_positive)
+        this.fillSlot("btnPositive", btnPositive.getElement());
+    }
+}

--- a/generics/components/organisms/Organism_ListAll.mjs
+++ b/generics/components/organisms/Organism_ListAll.mjs
@@ -50,6 +50,5 @@ export function Organism_ListAll (model){
 
         let listComponent3 = new Molecule_List(model.lists3)
         this.fillSlot('list3', listComponent3.getElement())
-
     }
 }

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -271,55 +271,55 @@ export function Template_Projects_Model ( model )
             text: model.text,
           }
         }
-        ]
-      },
-      content : {
-        organism_projectInfo : {
-          molecule_headingAboutImage : {
-            atom_heading4 : {
-              text : model.projModalHeading
+        ],
+        content : {
+          organism_projectInfo : {
+            molecule_headingAboutImage : {
+              atom_heading4 : {
+                text : model.projModalHeading
+              },
+              atom_text1 : {
+                text : model.projModalAbout
+              },
+              atom_image : {
+                src: model.projImageSrc,
+                alt: model.projImageAlt
+              }
             },
-            atom_text1 : {
-              text : model.projModalAbout
+            molecule_projectState : {
+              atom_text1 : {
+                text : model.previousBox
+              },
+              atom_icon1 : {
+                icon : model.icon6
+              }, atom_text2 : {
+                text : model.currentBox
+              },
+              atom_icon2 : {
+                icon : model.icon7
+              },
+              atom_text3 : {
+                text : model.nextBox
+              }
             },
-            atom_image : {
-              src: model.projImageSrc,
-              alt: model.projImageAlt
+            molecule_listCheckbox1 :{
+              atom_heading4 : {
+                text : model.subHeading1
+              },
+              items: model.items1
+            },
+            molecule_listCheckbox2 :{
+              atom_heading4 : {
+                text : model.subHeading2
+              },
+              items : model.items2
+            },
+            atom_buttonPositive : {
+              text : model.buttonPositive.text,
+              onClick : model.buttonPositive.onClick
             }
-          },
-          molecule_projectState : {
-            atom_text1 : {
-              text : model.previousBox
-            },
-            atom_icon1 : {
-              icon : model.icon6
-            }, atom_text2 : {
-              text : model.currentBox
-            },
-            atom_icon2 : {
-              icon : model.icon7
-            },
-            atom_text3 : {
-              text : model.nextBox
-            }
-          },
-          molecule_listCheckbox1 :{
-            atom_heading4 : {
-              text : model.subHeading1
-            },
-            items: model.items1
-          },
-          molecule_listCheckbox2 :{
-            atom_heading4 : {
-              text : model.subHeading2
-            },
-            items : model.items2
-          },
-          atom_buttonPositive : {
-            text : model.buttonPositive.text,
-            onClick : model.buttonPositive.onClick
           }
-        }
+        },
       },
       content : {
         organism_btn_positive_add_proj : {

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -274,44 +274,6 @@ export function Template_Projects_Model ( model )
         ]
       },
       content : {
-        organism_btn_positive_add_proj : {
-          molecule_text_input1: {
-            atom_text1 : {
-              text : model.modalHeading1
-            },
-            atom_input : {
-              type : model.inputType1,
-              placeholder : model.modalInput1 
-            }
-          },
-          molecule_text_input2 : {
-            atom_text1 : {
-              text : model.modalHeading2
-            },
-            atom_input : {
-              type : model.inputType2,
-              placeholder : model.modalInput2 
-            }
-          },
-          molecule_text_dropdown : {
-            atom_text1 : {
-              text : model.modalHeading3
-            },
-            atom_dropdown : {
-              text : model.text
-            }
-          },
-          atom_image : {
-            src : model.modalImage.src,
-            alt : model.modalImage.alt
-          },
-          atom_button_positive : {
-            text : model.buttonPositive.text,
-            onClick : model.buttonPositive.onClick
-          }
-        }
-      },
-      content : {
         organism_projectInfo : {
           molecule_headingAboutImage : {
             atom_heading4 : {
@@ -354,6 +316,44 @@ export function Template_Projects_Model ( model )
             items : model.items2
           },
           atom_buttonPositive : {
+            text : model.buttonPositive.text,
+            onClick : model.buttonPositive.onClick
+          }
+        }
+      },
+      content2 : {
+        organism_btn_positive_add_proj : {
+          molecule_text_input1: {
+            atom_text1 : {
+              text : model.modalHeading1
+            },
+            atom_input : {
+              type : model.inputType1,
+              placeholder : model.modalInput1 
+            }
+          },
+          molecule_text_input2 : {
+            atom_text1 : {
+              text : model.modalHeading2
+            },
+            atom_input : {
+              type : model.inputType2,
+              placeholder : model.modalInput2 
+            }
+          },
+          molecule_text_dropdown : {
+            atom_text1 : {
+              text : model.modalHeading3
+            },
+            atom_dropdown : {
+              text : model.text
+            }
+          },
+          atom_image : {
+            src : model.modalImage.src,
+            alt : model.modalImage.alt
+          },
+          atom_button_positive : {
             text : model.buttonPositive.text,
             onClick : model.buttonPositive.onClick
           }

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -244,8 +244,84 @@ export function Template_Projects_Model ( model )
               text: model.text,
             }
           },
-        ]
-      }
+        ],
+        // content : {
+        //   organism_btn_positive_add_proj : {
+        //     molecule_text_input1: {
+        //       atom_text1 : {
+        //         text : model.modalHeading1
+        //       },
+        //       atom_input : {
+        //         type : model.inputType1,
+        //         placeholder : model.modalInput1 
+        //       }
+        //     },
+        //     molecule_text_input2 : {
+        //       atom_text1 : {
+        //         text : model.modalHeading2
+        //       },
+        //       atom_input : {
+        //         type : model.inputType2,
+        //         placeholder : model.modalInput2 
+        //       }
+        //     },
+        //     molecule_text_dropdown : {
+        //       atom_text1 : {
+        //         text : model.modalHeading3
+        //       },
+        //       atom_dropdown : {
+        //         text : model.text
+        //       }
+        //     },
+        //     atom_image : {
+        //       src : model.modalImage.src,
+        //       alt : model.modalImage.alt
+        //     },
+        //     atom_button_positive : {
+        //       text : model.buttonPositive.text,
+        //       onClick : model.buttonPositive.onClick
+        //     }
+        //   }
+        // }  
+      },
+      content : {
+        organism_btn_positive_add_proj : {
+          molecule_text_input1: {
+            atom_text1 : {
+              text : model.modalHeading1
+            },
+            atom_input : {
+              type : model.inputType1,
+              placeholder : model.modalInput1 
+            }
+          },
+          molecule_text_input2 : {
+            atom_text1 : {
+              text : model.modalHeading2
+            },
+            atom_input : {
+              type : model.inputType2,
+              placeholder : model.modalInput2 
+            }
+          },
+          molecule_text_dropdown : {
+            atom_text1 : {
+              text : model.modalHeading3
+            },
+            atom_dropdown : {
+              text : model.text
+            }
+          },
+          atom_image : {
+            src : model.modalImage.src,
+            alt : model.modalImage.alt
+          },
+          atom_button_positive : {
+            text : model.buttonPositive.text,
+            onClick : model.buttonPositive.onClick
+          }
+        }
+      }   
     }
   };
 

--- a/generics/components/templates/Template_Projects_Model.mjs
+++ b/generics/components/templates/Template_Projects_Model.mjs
@@ -271,55 +271,7 @@ export function Template_Projects_Model ( model )
             text: model.text,
           }
         }
-        ],
-        content : {
-          organism_projectInfo : {
-            molecule_headingAboutImage : {
-              atom_heading4 : {
-                text : model.projModalHeading
-              },
-              atom_text1 : {
-                text : model.projModalAbout
-              },
-              atom_image : {
-                src: model.projImageSrc,
-                alt: model.projImageAlt
-              }
-            },
-            molecule_projectState : {
-              atom_text1 : {
-                text : model.previousBox
-              },
-              atom_icon1 : {
-                icon : model.icon6
-              }, atom_text2 : {
-                text : model.currentBox
-              },
-              atom_icon2 : {
-                icon : model.icon7
-              },
-              atom_text3 : {
-                text : model.nextBox
-              }
-            },
-            molecule_listCheckbox1 :{
-              atom_heading4 : {
-                text : model.subHeading1
-              },
-              items: model.items1
-            },
-            molecule_listCheckbox2 :{
-              atom_heading4 : {
-                text : model.subHeading2
-              },
-              items : model.items2
-            },
-            atom_buttonPositive : {
-              text : model.buttonPositive.text,
-              onClick : model.buttonPositive.onClick
-            }
-          }
-        },
+        ]
       },
       content : {
         organism_btn_positive_add_proj : {
@@ -358,7 +310,55 @@ export function Template_Projects_Model ( model )
             onClick : model.buttonPositive.onClick
           }
         }
-      }
+      },
+      content : {
+        organism_projectInfo : {
+          molecule_headingAboutImage : {
+            atom_heading4 : {
+              text : model.projModalHeading
+            },
+            atom_text1 : {
+              text : model.projModalAbout
+            },
+            atom_image : {
+              src: model.projImageSrc,
+              alt: model.projImageAlt
+            }
+          },
+          molecule_projectState : {
+            atom_text1 : {
+              text : model.previousBox
+            },
+            atom_icon1 : {
+              icon : model.icon6
+            }, atom_text2 : {
+              text : model.currentBox
+            },
+            atom_icon2 : {
+              icon : model.icon7
+            },
+            atom_text3 : {
+              text : model.nextBox
+            }
+          },
+          molecule_listCheckbox1 :{
+            atom_heading4 : {
+              text : model.subHeading1
+            },
+            items: model.items1
+          },
+          molecule_listCheckbox2 :{
+            atom_heading4 : {
+              text : model.subHeading2
+            },
+            items : model.items2
+          },
+          atom_buttonPositive : {
+            text : model.buttonPositive.text,
+            onClick : model.buttonPositive.onClick
+          }
+        }
+      },
     }
   };
 

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -4,8 +4,6 @@ import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_ButtonFilledPictures } from "../organisms/Organism_ButtonFilledPictures.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
 import { Modal_ProjectInfo } from "../organisms/Modal_ProjectInfo.mjs";
-import { Organism_ProjectInfo } from "../organisms/Organism_ProjectInfo.mjs";
-import { Modal_AddProjectProjectsView } from "../organisms/Modal_AddProjectProjectsView.mjs"
 import { Modal_AddProjectProjectsView } from "../organisms/Modal_AddProjectProjectsView.mjs"
 
 export function Template_Projects_View ( view )

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -56,7 +56,7 @@ export function Template_Projects_View ( view )
                 ${slot("new-modal")}
             </div>
             `
-            this.modal = new Modal_AddProjectProjectsView(model.content)
+            this.modal = new Modal_AddProjectProjectsView(model.content2)
 
             this.fillSlot("new-modal", this.modal.getElement());
 

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -30,7 +30,7 @@ export function Template_Projects_View ( view )
         let organismButtonFilledPictures = new Organism_ButtonFilledPictures( model.Organism_ButtonFilledPictures );
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
 
-        this.getElement().querySelector("atom_button-positive").addEventListener("click", (e) => {
+        this.getElement().querySelector(".atom_button-positive").addEventListener("click", (e) => {
             console.log('btn-project button pressed')     
 
             const modalId = document.getElementById('modal-addProject')

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -3,6 +3,7 @@ import { State } from "nd_frontend/core/actions/State.mjs";
 import { slot } from "nd_frontend/core/helpers.mjs";
 import { Organism_ButtonFilledPictures } from "../organisms/Organism_ButtonFilledPictures.mjs";
 import { Organism_Navbar } from "../organisms/Organism_Navbar.mjs"
+import { Modal_AddProjectProjectsView } from "../organisms/Modal_AddProjectProjectsView.mjs"
 
 export function Template_Projects_View ( view )
 {
@@ -13,8 +14,9 @@ export function Template_Projects_View ( view )
     {
         return `
         <div class="grid-template-projects">
-        ${slot("organismNavbar")}
+            ${slot("organismNavbar")}
             ${ slot( "organismButtonFilledPictures" ) }
+            <div id="modal-addProject"></div>
         </div>`;
     };
 
@@ -26,7 +28,21 @@ export function Template_Projects_View ( view )
         this.fillSlot("organismNavbar", organismNavbar.getElement())
 
         let organismButtonFilledPictures = new Organism_ButtonFilledPictures( model.Organism_ButtonFilledPictures );
-
         this.fillSlot( "organismButtonFilledPictures", organismButtonFilledPictures.getElement() );
+
+        this.getElement().querySelector("atom_button-positive").addEventListener("click", (e) => {
+            console.log('btn-project button pressed')     
+
+            const modalId = document.getElementById('modal-addProject')
+            
+            modalId.innerHTML = `
+                <div>
+                    ${slot("new-modal")}
+                </div>
+                `
+            this.modal = new Modal_AddProjectProjectsView(model.content)
+
+            this.fillSlot("new-modal", this.modal.getElement());
+        });
     };
 }

--- a/generics/components/templates/Template_Projects_View.mjs
+++ b/generics/components/templates/Template_Projects_View.mjs
@@ -47,7 +47,6 @@ export function Template_Projects_View ( view )
         })
 
         this.getElement().querySelector(".atom_button-positive").addEventListener("click", (e) => {
-            console.log('btn-project button pressed')
 
             const modalId = document.getElementById('modal-addProject')
 

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -132,7 +132,8 @@
   margin-right: 0.1em;
 }
 
-.modal-btn_proj_image {
+.modal-btn_proj_image > img {
   height: 141px;
   width: 141px;
+  align-self: end;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -116,3 +116,9 @@
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: 1fr;
 }
+
+.modal-btn_project-inner-wrap {
+  width: none !important;
+  background-color: white;
+
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -110,3 +110,9 @@
   border-radius: 12px;
   height: 628px;
 }
+
+.modal_btn_projects_first_section {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 1fr;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -123,5 +123,11 @@
   box-shadow: 5px 15px 5px rgb(0 0 0 / 4%);
   border: 1px solid #c6c7c8;
   border-radius: 12px;
+}
 
+.modal-btn_proj-section {
+  display: flex;
+  justify-content: end;
+  font-size: x-large;
+  margin-right: 0.1em;
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -118,7 +118,10 @@
 }
 
 .modal-btn_project-inner-wrap {
-  width: none !important;
+  width: none;
   background-color: white;
+  box-shadow: 5px 15px 5px rgb(0 0 0 / 4%);
+  border: 1px solid #c6c7c8;
+  border-radius: 12px;
 
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -187,6 +187,7 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: 1fr;
+  gap: 40px; 
 }
 
 .modal-btn_project-inner-wrap {
@@ -210,7 +211,7 @@
 }
 
 .modal-btn_proj_image > img {
-  height: 141px;
-  width: 141px;
-  align-self: end;
+  height: 154px;
+  width: 154px;
+  /* align-self: end; */
 }

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -115,7 +115,6 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: 1fr;
-  padding-top: 2em;
 }
 
 .modal-btn_project-inner-wrap {

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -131,3 +131,8 @@
   font-size: x-large;
   margin-right: 0.1em;
 }
+
+.modal-btn_proj_image {
+  height: 141px;
+  width: 141px;
+}

--- a/generics/stylesheets/modal.css
+++ b/generics/stylesheets/modal.css
@@ -115,6 +115,7 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: 1fr;
+  padding-top: 2em;
 }
 
 .modal-btn_project-inner-wrap {
@@ -130,6 +131,11 @@
   justify-content: end;
   font-size: x-large;
   margin-right: 0.1em;
+}
+
+.modal-btn_proj_image {
+  justify-self: center;
+  align-self: center;
 }
 
 .modal-btn_proj_image > img {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -4,7 +4,6 @@
 }
 
 .molecule_header-and-text {
-    /* padding: 3em; */
     margin: 0.5rem;
     display: grid;
     grid-template-columns: auto auto;
@@ -421,7 +420,6 @@
     width: inherit;
     justify-content: space-between;
     width: unset;
-    margin-top: 1em;
 }
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -180,11 +180,10 @@
     height: 35px;
 }
 
-.molecule_text_input_dropdown > div {
+.molecule_text_input_dropdown {
     display: grid;
     grid-template-columns: 1fr;
     grid-template-rows: repeat(3, 1fr);
-    grid-row-gap: 10px; 
     width: 234px;
 }
 
@@ -194,6 +193,7 @@
     justify-content: space-between;
     border: 1px solid red;
     width: unset;
+    margin-top: 1em;
 }
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown {
@@ -207,4 +207,8 @@
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > button > i {
     padding-left: 65px;
+}
+
+.molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > .dropdown-content {
+    width: 172px;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -191,7 +191,6 @@
     display: flex;
     width: inherit;
     justify-content: space-between;
-    border: 1px solid red;
     width: unset;
     margin-top: 1em;
 }
@@ -202,7 +201,7 @@
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > button {
     width: 173px;
-    height: 35px;
+    height: 38px;
 }
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > button > i {

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -172,3 +172,7 @@
     display:grid;
     grid-template-columns: auto auto;
 }
+
+.molecule_text_input_dropdown > div {
+    display: flex;
+}

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -174,5 +174,37 @@
 }
 
 .molecule_text_input_dropdown > div {
+    display: grid;
+    align-items: center;
+    grid-template-columns: 1fr 1fr;
+    height: 35px;
+}
+
+.molecule_text_input_dropdown > div {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(3, 1fr);
+    grid-row-gap: 10px; 
+    width: 234px;
+}
+
+.molecule_text_input_dropdown > .molecule_text_and_dropdown  {
     display: flex;
+    width: inherit;
+    justify-content: space-between;
+    border: 1px solid red;
+    width: unset;
+}
+
+.molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown {
+    align-self: baseline;
+}
+
+.molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > button {
+    width: 173px;
+    height: 35px;
+}
+
+.molecule_text_input_dropdown > .molecule_text_and_dropdown  > .dropdown > button > i {
+    padding-left: 65px;
 }

--- a/generics/stylesheets/molecules.css
+++ b/generics/stylesheets/molecules.css
@@ -185,6 +185,7 @@
     grid-template-columns: 1fr;
     grid-template-rows: repeat(3, 1fr);
     width: 234px;
+    justify-self: end;
 }
 
 .molecule_text_input_dropdown > .molecule_text_and_dropdown  {

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -242,7 +242,9 @@ nav > ul {
     grid-template-rows: 1fr 1fr;
     height: 389px;
     width: 568px;
-    /* align-items: self-end; */
+    border-bottom-left-radius: 15px;
+    border-bottom-right-radius: 15px;
+    padding-top: 2em;
 }
 
 .organism_btn_projects_modal > button {
@@ -250,6 +252,6 @@ nav > ul {
     height: fit-content;
     padding-left: 2em;
     padding-right: 2em;
-    margin-bottom: 2em;
     justify-self: center;
+    align-self: center;
 }

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -235,3 +235,21 @@ nav > ul {
 .mod-addToProj-cross {
     justify-content: end !important;
 }
+
+.organism_btn_projects_modal {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+    height: 389px;
+    width: 568px;
+    /* align-items: self-end; */
+}
+
+.organism_btn_projects_modal > button {
+    width: fit-content;
+    height: fit-content;
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-bottom: 2em;
+    justify-self: center;
+}

--- a/generics/stylesheets/organisms.css
+++ b/generics/stylesheets/organisms.css
@@ -334,7 +334,7 @@ nav > ul {
     width: 568px;
     border-bottom-left-radius: 15px;
     border-bottom-right-radius: 15px;
-    padding-top: 2em;
+    padding: 2em 2em 0;
 }
 
 .organism_btn_projects_modal > button {


### PR DESCRIPTION
UC-91-add-add-project-modal-to-project-view


## Description & motivation

Creating modal when clicking on button on projects view.
Modal contains new created organism and molecules.


## How to test

Add #UC-91-add-add-project-modal-to-project-view at the end of "nd_frontend" in package.json in UrbanCloud
Run and start the project.
Go to view /projects
Click on button above cards to see modal. 



## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
